### PR TITLE
Fix CPE formatting issue by correctly inserting a colon before patch versions

### DIFF
--- a/tools/vulnerability-lookup.nse
+++ b/tools/vulnerability-lookup.nse
@@ -183,6 +183,7 @@ action = function(host, port)
   for i, cpe in ipairs(port.version.cpe) do
     -- replace v2.2 prefix with v2.3
     cpe = cpe:gsub("cpe:/", "cpe:2.3:")
+    cpe = cpe:gsub("(%d+%.%d+%.%d+)([a-zA-Z]+)(%d*)", "%1:%2%3")
 
     output = get_vulns_by_cpe(cpe, port.version)
     if output then

--- a/tools/vulnerability-lookup.nse
+++ b/tools/vulnerability-lookup.nse
@@ -183,7 +183,7 @@ action = function(host, port)
   for i, cpe in ipairs(port.version.cpe) do
     -- replace v2.2 prefix with v2.3
     cpe = cpe:gsub("cpe:/", "cpe:2.3:")
-    cpe = cpe:gsub("(%d+%.%d+%.%d+)([a-zA-Z]+)(%d*)", "%1:%2%3")
+    cpe = cpe:gsub("(%d+%.%d+%.?%d*)([a-zA-Z]+%d*)", "%1:%2")
 
     output = get_vulns_by_cpe(cpe, port.version)
     if output then


### PR DESCRIPTION
This commit fixes an issue in the vulnerability-lookup script where CPE 2.3 strings  were not correctly formatted when they included a patch version (e.g., 'rc1').

### Problem:
Previously, CPEs with patch versions were incorrectly formatted. For example:
  - Incorrect:  cpe:2.3:a:isc:bind:9.8.2rc1
  - Correct:    cpe:2.3:a:isc:bind:9.8.2:rc1

### Solution:
- Modified the CPE transformation logic to correctly insert a colon before patch versions.
- Used a regex replacement to detect versioning patterns and adjust them accordingly.
- Ensured that this change does not affect already correctly formatted CPEs.

### Impact:
- Improves script accuracy when handling software versions with patch indicators.
- Resolves cases where vulnerabilities were not being retrieved due to misformatted queries.

Tested with various CPEs to verify correctness.