### PR TITLE
Small fixes on containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM debian
 
-RUN apt-get update && apt-get -y upgrade
-RUN apt install -y pipx git libtool python3 libssl-dev wget
+RUN apt-get update && apt-get -y upgrade && apt-get install -y pipx git libtool python3 libssl-dev wget
 RUN pipx install poetry && env
 ENV PATH=/root/.local/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian
 
-RUN apt-get update && apt-get -y upgrade && apt-get install -y pipx git libtool python3 libssl-dev wget
+RUN apt-get update && apt-get -y upgrade && apt-get install -y pipx git libtool python3 libssl-dev
 RUN pipx install poetry && env
 ENV PATH=/root/.local/bin:$PATH
 
@@ -18,7 +18,7 @@ ARG POSTGRES_PASSWORD
 
 
 WORKDIR ${APP_DIR}
-RUN wget "https://github.com/gocsaf/csaf/releases/download/v${CSAF_VERSION}/csaf-${CSAF_VERSION}-gnulinux-amd64.tar.gz" -O /opt/csaf_archive.tar.gz
+ADD "https://github.com/gocsaf/csaf/releases/download/v${CSAF_VERSION}/csaf-${CSAF_VERSION}-gnulinux-amd64.tar.gz" /opt/csaf_archive.tar.gz
 RUN mkdir /opt/csaf && tar xzvf /opt/csaf_archive.tar.gz -C "${CSAF_PATH}"
 RUN mv "${CSAF_PATH}/csaf-${CSAF_VERSION}-gnulinux-amd64/bin-linux-amd64" "${CSAF_PATH}"
 RUN rm -rf /opt/csaf_archive.tar.gz


### PR DESCRIPTION
- Prevent apt-get update running a long time before apt-get install (see commit for detail)
- Use Docker builtin command for download