### PR TITLE
fix: [feeders] enforce timezone in NVD API timestamp format

### DIFF
--- a/vulnerabilitylookup/feeders/nvd.py
+++ b/vulnerabilitylookup/feeders/nvd.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import requests
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable
 from uuid import uuid4
@@ -24,6 +24,26 @@ class NVD(AbstractFeeder):
 
         self.url_api = "https://services.nvd.nist.gov/rest/json/cves/2.0/?"
 
+    def format_nvd_timestamp(self, dt):
+        """
+        Format timestamps for NVD API queries in the required format.
+
+        Values must be entered in the extended ISO-8601 date/time format:
+        [YYYY]-[MM]-[DD]T[HH]:[MM]:[SS][Z]
+
+        Although the API documentation states the timezone is optional,
+        it appears to actually require it. Therefore, the timezone offset
+        is always included here.
+
+        See https://nvd.nist.gov/developers/vulnerabilities
+        """
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        iso_str = dt.strftime("%Y-%m-%dT%H:%M:%S")  # second precision only
+        tz_str = dt.strftime("%z")
+        iso_tz_str = f"{tz_str[:3]}:{tz_str[3:]}"  # ISO 8601 timezone format
+        return f"{iso_str}{iso_tz_str}"
+
     def update(self, stop: Callable[..., bool]) -> bool:
         query: dict[str, int | str]
         last_update: datetime | None
@@ -34,8 +54,8 @@ class NVD(AbstractFeeder):
         if last_update is None:
             query = {}
         else:
-            query = {'lastModStartDate': (last_update - timedelta(hours=10)).isoformat(),
-                     'lastModEndDate': (datetime.now() - timedelta(seconds=10)).isoformat()
+            query = {'lastModStartDate': self.format_nvd_timestamp(last_update - timedelta(hours=10)),
+                     'lastModEndDate': self.format_nvd_timestamp(datetime.now() - timedelta(seconds=10))
                      }
 
         last_update = datetime.now()


### PR DESCRIPTION
Although the NVD API documentation states that the timezone is optional, it appears that it is actually required. This change ensures that the timezone is always included in timestamps sent to the NVD API.

Resolves https://github.com/vulnerability-lookup/vulnerability-lookup/issues/187