### PR TITLE
fix: [website] respect 'is_active' checkbox on notifications

### DIFF
--- a/website/web/views/user.py
+++ b/website/web/views/user.py
@@ -752,6 +752,7 @@ def process_notification(notification_id: int = 0) -> str | WerkzeugResponse:
                 vendor=form_vendor_product.vendor.data.lower(),
                 product=form_vendor_product.product.data.lower(),
                 frequency=form_vendor_product.frequency.data,
+                is_active=form_vendor_product.is_active.data,
                 notification_type="vulnerability_cpe",
                 user_id=current_user.id,
             )
@@ -801,6 +802,7 @@ def process_notification(notification_id: int = 0) -> str | WerkzeugResponse:
                 notification.organization_id = linked_org.id
                 notification.product_id = linked_product.id
                 notification.frequency = form_organization_product.frequency.data
+                notification.is_active = form_organization_product.is_active.data
                 notification.notification_type = "vulnerability_organization"
             except AssertionError as e:
                 flash(f"{e}", "danger")
@@ -824,6 +826,7 @@ def process_notification(notification_id: int = 0) -> str | WerkzeugResponse:
                     organization_id=linked_org.id,
                     product_id=linked_product.id,
                     frequency=form_organization_product.frequency.data,
+                    is_active=form_organization_product.is_active.data,
                     notification_type="vulnerability_organization",
                     user_id=current_user.id,
                 )


### PR DESCRIPTION
The form’s `is_active` value was ignored when creating notifications, causing them to default to active (`True`) regardless of checkbox state. Also, editing notifications from the organization/product form did not update `is_active`, so changes to the active status were not applied. This ensures `form.is_active.data` is handled correctly in both cases.

Resolves https://github.com/vulnerability-lookup/vulnerability-lookup/issues/193