### PR TITLE
fix: CWEs routes registered when user_accounts = false

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -56,7 +56,9 @@ with application.app_context():
             application.register_blueprint(views.vulnerability_disclosure_bp)
             application.register_blueprint(views.vulnerability_disclosures_bp)
         application.register_blueprint(views.stats_bp)
-        application.register_blueprint(views.CWEs_bp)
+
+    # CWEs 
+    application.register_blueprint(views.CWEs_bp)
 
     # API v1
     application.register_blueprint(apiv1_blueprint)


### PR DESCRIPTION
Hello :wave: 

I had a problem when trying to use the app without user accounts: `Could not build url for endpoint CWEs_bp.index` - making the whole website 500 (because it's required in navbar menu).

