### PR TITLE
fix: [API] use dedicated parser for get user list. Fixes broken endpo…

### DIFF
--- a/website/web/api/v1/user.py
+++ b/website/web/api/v1/user.py
@@ -214,7 +214,7 @@ class UsersList(Resource):  # type: ignore[misc]
     @admin_permission.require(http_exception=403)  # type: ignore[misc]
     def get(self) -> Tuple[ResultType, int]:
         """List all users. Only available to administrators."""
-        args = parser.parse_args()
+        args = parser_get_users.parse_args()
         page = args.pop("page", 1)  # 1-based page index
         per_page = args.pop("per_page", 10)  # Number of records per page
 


### PR DESCRIPTION
…int.


Looks like it was using the other parser, which now required some params.

Kept getting this:
{'errors': {'login': 'Login. Missing required parameter in the JSON body', 'name': 'Display name (firstname, lastname). Missing required parameter in the JSON body', 'email': 'Email. Missing required parameter in the JSON body'}, 'message': 'Input payload validation failed'}