### PR TITLE
fix: [api] correct inconsistent max vendor limit for /vendors/ranking…

### DIFF
--- a/website/web/api/v1/stats.py
+++ b/website/web/api/v1/stats.py
@@ -375,7 +375,7 @@ class VendorsRanking(Resource):  # type: ignore[misc]
 
         # Cap limit at 10
         if not limit or limit > 10:
-            limit = 100
+            limit = 10
 
         result = vulnerabilitylookup.get_top_vendors(
             top_n=limit, period=period, source=source


### PR DESCRIPTION
… endpoint

default for parser, comment above, and if all seem to indicate the limit should be 10.