### PR TITLE
fix: [core] conditional metadata handling in source-aware functions

### DIFF
--- a/vulnerabilitylookup/vulnerabilitylookup.py
+++ b/vulnerabilitylookup/vulnerabilitylookup.py
@@ -75,12 +75,15 @@ class VulnerabilityLookup:
     ) -> dict[str, list[tuple[str, dict[str, Any]]]]:
         _vid = vulnerability_id.lower()
         to_return: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+        found = False
         for linked_vuln in self.storage.smembers(f"{_vid}:link"):
-            if vuln := self.get_vulnerability(linked_vuln):
-                if source := self.get_vulnerability_source(linked_vuln):
-                    to_return[source].append((linked_vuln, vuln))
-                else:
-                    self.logger.warning(f"Unable to find source for {linked_vuln}")
+            for with_meta in [False, True]:
+                if vuln := self.get_vulnerability(linked_vuln, with_meta=with_meta):
+                    if source := self.get_vulnerability_source(linked_vuln):
+                        to_return[source].append((linked_vuln, vuln))
+                        found = True
+            if not found:
+                self.logger.warning(f"Unable to find source for {linked_vuln}")
         return to_return
 
     def get_vulnerability_source(self, vulnerability_id: str) -> str | None:


### PR DESCRIPTION
This PR ensures that source-aware functions in `class VulnerabilityLookup` correctly retrieve vulnerabilities regardless of whether a source stores them directly (e.g., CVE List V5) or indirectly via metadata UUID references (e.g., NVD).

|Function|Change|
|---|---|
|`get_last()`|Sets `with_meta=True` if the vulnerability has metadata for the specified source.|
|`get_vendor_product_vulnerabilities_since()`|Inspects each vulnerability for metadata corresponding to its source; enriches if indirect meta is used.|
|`get_vendor_vulnerabilities()`|Checks each vulnerability for source-specific metadata; applies `with_meta=True` when necessary.|
|`get_vendor_product_vulnerabilities()`|Same as above; ensures per-source enrichment for each vulnerability.|
|`get_linked_emb3d()`|Fetches metadata per linked vulnerability for the `emb3d` source and applies enrichment.|
|`get_linked_vulnerabilities()`|Tries both `with_meta=False` and `with_meta=True` for each linked vulnerability, adding both to the result grouped by source. Logs only if both fail.|

**Impact:**

- Correctly handles vulnerabilities from sources using indirect metadata references.
- Preserves behavior for vulnerabilities without metadata.
- Ensures proper per-source grouping for linked vulnerabilities.
- No breaking changes; existing workflows should remain intact.
- API `/api/vulnerability/search/` should be able to show content from NVD correctly.

Resolves https://github.com/vulnerability-lookup/vulnerability-lookup/issues/241