### PR TITLE
chg: [api:bundle] remove duplicate admin role check for delete endpoint

### DIFF
--- a/website/web/api/v1/bundle.py
+++ b/website/web/api/v1/bundle.py
@@ -147,8 +147,6 @@ class BundleItem(Resource):  # type: ignore[misc]
     @admin_permission.require(http_exception=403)  # type: ignore[misc]
     def delete(self, bundle_uuid: str) -> Tuple[dict[Any, Any], int]:
         """Endpoint for deleting a bundle. Only an admin can delete a bundle."""
-        if not current_user.is_admin:
-            return abort(403, "You cannot delete this bundle.")
         obj = Bundle.query.filter(Bundle.uuid == bundle_uuid).first()
         if obj:
             db.session.delete(obj)


### PR DESCRIPTION

Function already has @admin_permission.require(http_exception=403) which should be enough?