### PR TITLE
fix: run API tests again

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13' , '3.14']
     name: Python ${{ matrix.python-version }} sample
 
     steps:
@@ -44,9 +44,14 @@ jobs:
         mv valkey-tmp ../valkey
         pushd ..
         pushd valkey
-        make
+        make -j $(nproc)
         popd
         popd
+
+    - name: Install KvRocks
+      run: |
+        wget https://github.com/RocksLabs/kvrocks-fpm/releases/download/202510222/kvrocks_2.13.0-1_amd64.deb -O kvrocks.deb
+        sudo dpkg -i kvrocks.deb
 
     - name: Setup PostgreSQL
       uses: Harmon758/postgresql-action@v1.0.0
@@ -79,7 +84,7 @@ jobs:
         poetry run flask --app website.app db stamp head
         poetry run flask --app website.app create_admin --login admin --password admin --email admin@local.host
         export API_KEY=`poetry run flask --app website.app user_get_api_key --login admin`
-        poetry run run_backend --start
+        timeout 1m poetry run run_backend --start
         poetry run pysec_importer &
         poetry run start_website &
         sleep 60
@@ -90,3 +95,14 @@ jobs:
         poetry run stop
       env:
         TESTING: gh_action
+
+    - name: Cache / Valkey logs
+      if: ${{ always() }}
+      run: |
+        cat cache/cache.log
+
+    - name: Storage / Kvrocks logs
+      if: ${{ always() }}
+      run: |
+        ls storage
+        cat storage/*log*

--- a/bin/run_backend.py
+++ b/bin/run_backend.py
@@ -36,6 +36,7 @@ def check_running(name: str) -> bool:
         print(f'Unable to connect to redis: {e}')
         return False
 
+
 def launch_cache(storage_directory: Path | None=None) -> None:
     if not storage_directory:
         storage_directory = get_homedir()
@@ -73,6 +74,7 @@ def shutdown_storage() -> None:
     redis = Redis(get_config('generic', 'storage_db_hostname'), get_config('generic', 'storage_db_port'))
     redis.shutdown()
     print('Kvrocks storage database shutdown.')
+
 
 def launch_migratons() -> None:
     p = get_postgres_info()

--- a/cache/cache.conf
+++ b/cache/cache.conf
@@ -349,7 +349,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # the server to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile ""
+logfile "cache.log"
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.

--- a/storage/kvrocks.conf
+++ b/storage/kvrocks.conf
@@ -19,6 +19,16 @@ bind 0.0.0.0
 # unixsocket /tmp/kvrocks.sock
 # unixsocketperm 777
 
+# Allows a parent process to open a socket and pass its FD down to kvrocks as a child
+# process. Useful to reserve a port and prevent race conditions.
+#
+# PLEASE NOTE:
+# If this is overridden to a value other than -1, the bind and tls* directives will be
+# ignored.
+#
+# Default: -1 (not overridden, defer to creating a connection to the specified port)
+socket-fd -1
+
 # Accept connections on the specified port, default is 6666.
 port 10002
 
@@ -30,7 +40,7 @@ workers 8
 
 # By default, kvrocks does not run as a daemon. Use 'yes' if you need it.
 # It will create a PID file when daemonize is enabled, and its path is specified by pidfile.
-daemonize no
+daemonize yes
 
 # Kvrocks implements the cluster solution that is similar to the Redis cluster solution.
 # You can get cluster information by CLUSTER NODES|SLOTS|INFO command, it also is
@@ -117,22 +127,27 @@ db-name storage.db
 dir ./
 
 # You can configure where to store your server logs by the log-dir.
-# If you don't specify one, we will use the above `dir` as our default log directory.
-# We also can send logs to stdout/stderr is as simple as:
+# If you don't specify one, we will use the above `dir` and
+# also stdout as our default log directory, e.g. `/tmp/kvrocks,stdout`.
+# `log-dir` can contain multiple destinations, separated by comma (,).
+# And every destination can be optionally followed by a corresponding log level,
+# separated by colon (:), e.g. `/tmp/my-log-dir:info,stdout:warning,stderr:error`.
+# If no log level attached with a destination,
+# the config option `log-level` will be used.
 #
-log-dir ./
+# log-dir /tmp/kvrocks,stdout
 
 # Log level
-# Possible values: info, warning, error, fatal
+# Possible values: debug, info, warning, error, fatal
 # Default: info
-log-level info
+log-level warning
 
 # You can configure log-retention-days to control whether to enable the log cleaner
 # and the maximum retention days that the INFO level logs will be kept.
 #
-# if set to -1, that means to disable the log cleaner.
-# if set to 0, all previous INFO level logs will be immediately removed.
-# if set to between 0 to INT_MAX, that means it will retent latest N(log-retention-days) day logs.
+# if set to negative or 0, that means to disable the log cleaner.
+# if set to between 1 to INT_MAX,
+# that means it will retent latest N(log-retention-days) day logs.
 
 # By default the log-retention-days is -1.
 log-retention-days -1
@@ -163,6 +178,20 @@ slave-read-only yes
 #
 # By default the priority is 100.
 slave-priority 100
+
+# Change the default timeout in milliseconds for socket connect during replication.
+# The default value is 3100, and 0 means no timeout.
+#
+# If the master is unreachable before connecting, not having a timeout may block future
+# 'clusterx setnodes' commands because the replication thread is blocked on connect.
+replication-connect-timeout-ms 3100
+
+# Change the default timeout in milliseconds for socket recv during fullsync.
+# The default value is 3200, and 0 means no timeout.
+#
+# If the master is unreachable when fetching SST files, not having a timeout may block
+# future 'clusterx setnodes' commands because the replication thread is blocked on recv.
+replication-recv-timeout-ms 3200
 
 # TCP listen() backlog.
 #
@@ -291,6 +320,10 @@ max-replication-mb 0
 # Default: 0
 max-io-mb 0
 
+# Whether to cache blob files within the block cache.
+# Default: no
+enable-blob-cache no
+
 # The maximum allowed space (in GB) that should be used by RocksDB.
 # If the total size of the SST files exceeds max_allowed_space, writes to RocksDB will fail.
 # Please see: https://github.com/facebook/rocksdb/wiki/Managing-Disk-Space-Utilization
@@ -318,10 +351,9 @@ max-bitmap-to-string-mb 16
 redis-cursor-compatible yes
 
 # Whether to enable the RESP3 protocol.
-# NOTICE: RESP3 is still under development, don't enable it in production environment.
 #
-# Default: no
-# resp3-enabled no
+# Default: yes
+# resp3-enabled yes
 
 # Maximum nesting depth allowed when parsing and serializing
 # JSON documents while using JSON commands like JSON.SET.
@@ -348,6 +380,18 @@ json-storage-format json
 #
 # Default: no
 txn-context-enabled no
+
+# Define the histogram bucket values.
+#
+# If enabled, those values will be used to store the command execution latency values
+# in buckets defined below. The values should be integers and must be sorted.
+# An implicit bucket (+Inf in prometheus jargon) will be added to track the highest values
+# that are beyond the bucket limits.
+
+# NOTE: This is an experimental feature. There might be some performance overhead when using this
+# feature, please be aware.
+# Default: disabled
+# histogram-bucket-boundaries  10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
 
 ################################## TLS ###################################
 
@@ -458,6 +502,11 @@ slowlog-log-slower-than 100000
 # You can reclaim memory used by the slow log with SLOWLOG RESET.
 slowlog-max-len 128
 
+# Dump slow logs to logfiles with this level, off means don't dump.
+# Possible values: info, warning, off
+# Default: off
+slowlog-dump-logfile-level off
+
 # If you run kvrocks from upstart or systemd, kvrocks can interact with your
 # supervision tree. Options:
 #   supervised no      - no supervision interaction
@@ -535,7 +584,7 @@ compaction-checker-cron * 0-7 * * *
 # file) to compact, in order to free disk space.
 # However, if a specific SST file was created more than "force-compact-file-age" seconds
 # ago, and its percentage of deleted keys is higher than
-# "force-compact-file-min-deleted-percentage", it will be forcely compacted as well.
+# "force-compact-file-min-deleted-percentage", it will be forcibly compacted as well.
 
 # Default: 172800 seconds; Range: [60, INT64_MAX];
 # force-compact-file-age 172800
@@ -578,8 +627,8 @@ compaction-checker-cron * 0-7 * * *
 #                  command, reduces resource consumption, improves migration
 #                  efficiency, and can implement a finer rate limit.
 #
-# Default: redis-command
-migrate-type redis-command
+# Default: raw-key-value
+migrate-type raw-key-value
 
 # If the network bandwidth is completely consumed by the migration task,
 # it will affect the availability of kvrocks. To avoid this situation,
@@ -619,6 +668,13 @@ migrate-batch-size-kb 16
 # Default: 16M
 migrate-batch-rate-limit-mb 16
 
+
+# If it is set to yes, kvrocks will skip the deallocation of block cache
+# while closing the database to speed up the shutdown
+#
+# Default: no
+# skip-block-cache-deallocation-on-close no
+
 ################################ ROCKSDB #####################################
 
 # Specify the capacity of column family block cache. A larger block cache
@@ -636,13 +692,6 @@ rocksdb.block_cache_size 4096
 #
 # default lru
 rocksdb.block_cache_type lru
-
-# A global cache for table-level rows in RocksDB. If almost always point
-# lookups, enlarging row cache may improve read performance. Otherwise,
-# if we enlarge this value, we can lessen metadata/subkey block cache size.
-#
-# Default: 0 (disabled)
-rocksdb.row_cache_size 0
 
 # Number of open files that can be used by the DB.  You may need to
 # increase this if your database has a large working set. Value -1 means
@@ -683,6 +732,13 @@ rocksdb.target_file_size_base 128
 # allowed.
 rocksdb.max_write_buffer_number 4
 
+# The minimum number of write buffers that will be merged together
+# during compaction.
+#
+# Default: 1
+rocksdb.min_write_buffer_number_to_merge 1
+
+
 # Maximum number of concurrent background jobs (compactions and flushes).
 # For backwards compatibility we will set `max_background_jobs =
 # max_background_compactions + max_background_flushes` in the case where user
@@ -708,6 +764,16 @@ rocksdb.max_background_flushes -1
 # Default: 2
 rocksdb.max_subcompactions 2
 
+# If enabled WAL records will be compressed before they are written. Only
+# ZSTD (= kZSTD) is supported (until streaming support is adapted for other
+# compression types). Compressed WAL records will be read in supported
+# versions (>= RocksDB 7.4.0 for ZSTD) regardless of this setting when
+# the WAL is read.
+#
+# Accept value: "no", "zstd"
+# Default is no
+rocksdb.wal_compression no
+
 # In order to limit the size of WALs, RocksDB uses DBOptions::max_total_wal_size
 # as the trigger of column family flush. Once WALs exceed this size, RocksDB
 # will start forcing the flush of column families to allow deletion of some
@@ -728,6 +794,12 @@ rocksdb.max_subcompactions 2
 #
 # default is 512MB
 rocksdb.max_total_wal_size 512
+
+# Whether to print malloc stats together with rocksdb.stats when printing to LOG.
+#
+# Accepted values: "yes", "no"
+# Default: yes
+rocksdb.dump_malloc_stats yes
 
 # We implement the replication with rocksdb WAL, it would trigger full sync when the seq was out of range.
 # wal_ttl_seconds and wal_size_limit_mb would affect how archived logs will be deleted.
@@ -794,6 +866,15 @@ rocksdb.compression_level 32767
 # Default: 2 MB
 rocksdb.compaction_readahead_size 2097152
 
+# Enable compression from n levels of LSM-tree.
+# By default compression is disabled for the first two levels (L0 and L1),
+# because it may contain the frequently accessed data, so it'd be better
+# to use uncompressed data to save the CPU.
+# Value: [0, 7) (upper boundary is kvrocks maximum levels number)
+#
+# Default: 2
+rocksdb.compression_start_level 2
+
 # he limited write rate to DB if soft_pending_compaction_bytes_limit or
 # level0_slowdown_writes_trigger is triggered.
 
@@ -809,14 +890,18 @@ rocksdb.delayed_write_rate 0
 #  Default: no
 rocksdb.enable_pipelined_write no
 
-# Soft limit on number of level-0 files. We start slowing down writes at this
-#  point. A value <0 means that no writing slow down will be triggered by
-# number of files in level-0.
+# Soft limit on number of level-0 files. We slow down writes at this point.
+# A value of 0 means that no writing slowdown will be triggered by number
+# of files in level-0. If this value is smaller than
+# rocksdb.level0_file_num_compaction_trigger, this will be set to
+# rocksdb.level0_file_num_compaction_trigger instead.
 #
 # Default: 20
 rocksdb.level0_slowdown_writes_trigger 20
 
-# Maximum number of level-0 files.  We stop writes at this point.
+# Maximum number of level-0 files. We stop writes at this point. If this value
+# is smaller than rocksdb.level0_slowdown_writes_trigger, this will be set to
+# rocksdb.level0_slowdown_writes_trigger instead.
 #
 # Default: 40
 rocksdb.level0_stop_writes_trigger 40
@@ -960,6 +1045,11 @@ rocksdb.write_options.memtable_insert_hint_per_batch no
 # Default: yes
 rocksdb.rate_limiter_auto_tuned yes
 
+# If enabled, rocksdb will use partitioned full filters for each SST file.
+#
+# Default: yes
+rocksdb.partition_filters yes
+
 # Enable this option will schedule the deletion of obsolete files in a background thread
 # on iterator destruction. It can reduce the latency if there are many files to be removed.
 # see https://github.com/facebook/rocksdb/wiki/IO#avoid-blocking-io
@@ -974,6 +1064,22 @@ rocksdb.rate_limiter_auto_tuned yes
 # Default: 0
 # rocksdb.write_options.write_batch_max_bytes 0
 
+# RocksDB will try to limit number of bytes in one compaction to be lower than this threshold.
+# If set to 0, it will be sanitized to [25 * target_file_size_base]
+#
+# Default: 0
+rocksdb.max_compaction_bytes 0
+
+# Set the delete rate limit in bytes per second for SST files deletion.
+# zero means disable delete rate limiting and delete files immediately.
+# In scenarios involving frequent database iterations (e.g., HGETALL, SCAN) obsolete WAL files
+# may be deleted synchronously, causing latency spikes. Enabling this option activates a
+# controlled slow deletion mechanism, which also resolves WAL deletion latency issues when
+# an iterator is released.
+# see https://github.com/facebook/rocksdb/wiki/Slow-Deletion
+#
+# Default: 0
+rocksdb.sst_file_delete_rate_bytes_per_sec 0
+
 ################################ NAMESPACE #####################################
 # namespace.test change.me
-backup-dir .//backup

--- a/storage/run_kvrocks.sh
+++ b/storage/run_kvrocks.sh
@@ -5,6 +5,9 @@ set -x
 
 if [ -f ../../kvrocks/build/kvrocks ]; then
     ../../kvrocks/build/kvrocks -c kvrocks.conf
+elif [ -x "$(command -v kvrocks)" ]; then
+    echo 'kvrocks does not seem to be built locally, using the system-wide install instead.'
+    kvrocks -c kvrocks.conf
 else
     echo 'kvrocks does not seem to be installed locally, using docker instead.'
     echo 'We assume you have docker installed in rootless mode, following the instructions here: https://docs.docker.com/engine/security/rootless/'


### PR DESCRIPTION
Use debian package for kvrocks in test suite, add test on python 3.14.

Few changes in the python API that should be fixed (limit on user creation/hour, unable to the the API key for a user): https://github.com/vulnerability-lookup/PyVulnerabilityLookup/commit/8a1ff93f87acf6f8d35fc1cb342629559fdab724

But ready to merge otherwise.