### PR TITLE
fix: [api] correct comment and bundle per_page range check

### DIFF
--- a/website/web/api/v1/bundle.py
+++ b/website/web/api/v1/bundle.py
@@ -179,7 +179,7 @@ class BundlesList(Resource):  # type: ignore[misc]
         per_page = args.pop("per_page", 10)  # Number of records per page
 
         # Enforce maximum per_page limit
-        if per_page not in [1, ..., 200]:
+        if not (1 <= per_page <= 200):
             per_page = 100
 
         # Calculate the offset based on page and per_page

--- a/website/web/api/v1/comment.py
+++ b/website/web/api/v1/comment.py
@@ -191,7 +191,7 @@ class CommentsList(Resource):  # type: ignore[misc]
         per_page = args.pop("per_page", 10)  # Number of records per page
 
         # Enforce maximum per_page limit
-        if per_page not in [1, ..., 200]:
+        if not (1 <= per_page <= 200):
             per_page = 100
 
         # Calculate the offset based on page and per_page


### PR DESCRIPTION
[1, ..., 200] doesn't work apparently :)

<img width="377" height="460" alt="image" src="https://github.com/user-attachments/assets/2d50371e-48a6-4cd5-b33a-a0e697c7c78b" />


didn't test updated code in vuln lookup itself so please double check / verify.