### PR TITLE
[codex] Document bulk data access guidance

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -10,6 +10,20 @@ is a Python library to access Vulnerability-Lookup via its REST API.
 ```{openapi} _static/files/swagger.json
 ```
 
+## Bulk access
+
+Use the API for targeted lookups, correlation, and interactive integrations.
+For bulk synchronization or mirroring, prefer the JSON dumps published by the public instance:
+
+```text
+https://vulnerability.circl.lu/dumps/
+```
+
+The dumps are intended for clients that need to consume all available vulnerability data.
+Avoid enumerating the API to rebuild a complete local copy when a dump is available.
+
+For monitoring recent changes, Atom and RSS feeds are also available; see {doc}`feeds`.
+
 ## Response format
 
 All list endpoints return a paginated response with the following structure:


### PR DESCRIPTION
## Summary

- Add a focused Bulk access section to the API v1 documentation.
- Clarify that the API is intended for targeted lookups, correlation, and interactive integrations.
- Point bulk synchronization and mirroring clients to the public JSON dumps instead of API enumeration.
- Mention Atom/RSS feeds for monitoring recent changes.

Closes #383

## Validation

- `git diff --check`
- `poetry run sphinx-build -W -E -b html docs /tmp/vulnerability-lookup-docs-html`