### PR TITLE
fix: show disclosure content to reporter on detail page

### DIFF
--- a/website/web/templates/vulnerability_disclosures/disclosure.html
+++ b/website/web/templates/vulnerability_disclosures/disclosure.html
@@ -1,10 +1,24 @@
 {% extends "main.html" %}
+{% from 'bootstrap5/utils.html' import render_icon %}
 {% block title %}Vulnerability Disclosure - {{ vulnerability_disclosure.title }}{% endblock %}
 {% block content %}
-<div class="row mb-3">
+{% set is_owner = current_user.is_authenticated and current_user.id == vulnerability_disclosure.reporter_id %}
+{% set is_publicly_visible = vulnerability_disclosure.state.name == "disclosed" or (vulnerability_disclosure.state.name == "approved" and vulnerability_disclosure.days_until_disclosure() <= 0) %}
+{% set can_view_content = is_publicly_visible or is_owner or (current_user.is_authenticated and current_user.is_admin) %}
+<div class="row mb-3 align-items-center">
   <div class="col">
     <h1>{{ vulnerability_disclosure.title }}</h1>
   </div>
+  {% if is_owner %}
+  <div class="col-auto">
+    <a class="btn btn-outline-primary" href="{{ url_for('vulnerability_disclosure_bp.form', vulnerability_disclosure_id=vulnerability_disclosure.id) }}">
+      {{ render_icon('pen') }} Edit
+    </a>
+    <a class="btn btn-outline-secondary" href="{{ url_for('vulnerability_disclosure_bp.comments', vulnerability_disclosure_id=vulnerability_disclosure.id) }}">
+      {{ render_icon('book') }} Comments
+    </a>
+  </div>
+  {% endif %}
 </div>
 
 <div class="card shadow-sm mb-4">
@@ -34,7 +48,12 @@
   </div>
 </div>
 
-{% if vulnerability_disclosure.state.name == "disclosed" or (vulnerability_disclosure.state.name == "approved" and vulnerability_disclosure.days_until_disclosure() <= 0) %}
+{% if can_view_content %}
+{% if not is_publicly_visible %}
+<div class="alert alert-info" role="alert">
+  This disclosure is not yet public. The details below are visible to you because you are {{ 'the reporter' if is_owner else 'an administrator' }}.
+</div>
+{% endif %}
 <div class="card shadow-sm mb-4">
   <div class="card-header">
     <h5 class="mb-0">Description</h5>


### PR DESCRIPTION
## Summary
- After creating a disclosure, the UUID link in the success flash led to a page that didn't display the submitted content unless the disclosure was already public — forcing reporters to go through the disclosures index → Edit just to view what they had just submitted.
- The detail view now shows the full Description and Details to the reporter (and admins) regardless of state, with a clear "not yet public" notice.
- Adds **Edit** and **Comments** shortcut buttons on the page for the reporter so the index detour is no longer needed.

Public/non-owner viewers see no change in behavior — content stays hidden until the disclosure transitions to `disclosed` (or `approved` past the disclosure date).

Closes #388

## Test plan
- [ ] As a reporter, submit a new disclosure → click the UUID link in the flash → verify Description, Details, Edit, and Comments are visible.
- [ ] As the same reporter, visit the disclosure when state is `reported` / `under_review` etc. → content visible with the "not yet public" notice.
- [ ] As an admin (different user), visit a non-public disclosure → content visible with the notice.
- [ ] As an unauthenticated user or a different non-admin user, visit a non-public disclosure → only status block shown (no content).
- [ ] Once the disclosure transitions to `disclosed`, the notice disappears and content is visible to everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)