### PR TITLE
fix(ui): expose additional CSAF vulnerability fields

### DIFF
--- a/website/web/templates/vulnerability_templates.html
+++ b/website/web/templates/vulnerability_templates.html
@@ -1848,6 +1848,44 @@
               </div>
             {% endfor %}
           {% endif %}
+
+          {% if vuln.get('product_status') %}
+            {% set status_labels = {
+              'first_affected': 'First affected',
+              'known_affected': 'Known affected',
+              'fixed': 'Fixed',
+              'known_not_affected': 'Known not affected',
+              'under_investigation': 'Under investigation',
+              'recommended': 'Recommended'
+            } %}
+            <div class="mt-2">
+              <div class="small text-muted fw-semibold mb-1">Product status</div>
+              {% for status_key, product_ids in vuln['product_status'].items() %}
+                {% if product_ids %}
+                  <div class="mb-1">
+                    <span class="badge bg-light text-dark border me-1">{{ status_labels.get(status_key, status_key | replace('_', ' ') | title) }}</span>
+                    {% for product_id in product_ids %}
+                      <span class="badge bg-secondary me-1">{{ product_id }}</span>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              {% endfor %}
+            </div>
+          {% endif %}
+
+          {% if vuln.get('threats') %}
+            <div class="mt-2">
+              <div class="small text-muted fw-semibold mb-1">Threats</div>
+              {% for threat in vuln['threats'] %}
+                <div class="mb-1">
+                  {% if threat.get('category') %}
+                    <span class="badge bg-danger me-1">{{ threat['category'] | replace('_', ' ') | title }}</span>
+                  {% endif %}
+                  {{ threat.get('details', '') }}
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
### Motivation
- Issue #381 indicates CSAF advisories often contain per-vulnerability fields that are present in the JSON but not shown in the UI, reducing the usefulness of the rendered advisory. 
- Surface key CSAF details (product status and threats) in the vulnerability card so analysts can see them without inspecting raw JSON.

### Description
- Update `website/web/templates/vulnerability_templates.html` to render `vulnerabilities[].product_status` as labeled status groups with product ID badges. 
- Add rendering for `vulnerabilities[].threats` showing a category badge and the threat `details` text. 
- Implement the change in the generic CSAF renderer so it applies to all CSAF sources that use that template and preserves the compact card layout.

### Testing
- Ran `git diff -- website/web/templates/vulnerability_templates.html` to verify the template changes and the diff output (succeeded). 
- Committed the change with `git commit -m "fix(ui): expose additional CSAF vulnerability fields"` (succeeded). 
- Created the PR metadata via the project `make_pr` helper (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc888504d083248e2c06c1bf8a6173)