### PR TITLE
fix: [website] add timezone offset to bundle/comment timestamp format…

### DIFF
--- a/website/web/templates/bundles/bundles.html
+++ b/website/web/templates/bundles/bundles.html
@@ -53,7 +53,7 @@
         <div>
           <h5 class="card-title mb-0"><a href="{{ url_for('bundle_bp.get', bundle_uuid=bundle.uuid) }}">{{ bundle.name | safe }}</a></h5>
           <small class="text-body-secondary">
-            <span class="datetime" title="{{ bundle.creation_timestamp | string_to_datetime('%Y-%m-%dT%H:%M') }}">{{ bundle.creation_timestamp | datetimeformat('%Y-%m-%dT%H:%M:%S') }}</span>
+            <span class="datetime" title="{{ bundle.creation_timestamp | string_to_datetime('%Y-%m-%dT%H:%M') }}">{{ bundle.creation_timestamp | datetimeformat('%Y-%m-%dT%H:%M:%S%z') }}</span>
             by <a href="{{ url_for('user_bp.profile', login=bundle.author.login) }}">{{ bundle.author.name }}</a>
             {% set origin = bundle.vulnerability_lookup_origin | string %}
             {% if origin != local_instance_uuid %}

--- a/website/web/templates/comments/comments.html
+++ b/website/web/templates/comments/comments.html
@@ -61,7 +61,7 @@
       <div>
         <h5 class="card-title mb-0"><a href="{{ url_for('comment_bp.get', comment_uuid=comment.uuid) }}">{{ comment.title | safe }}</a></h5>
         <small class="text-body-secondary">
-          <span class="datetime" title="{{ comment.creation_timestamp | string_to_datetime('%Y-%m-%dT%H:%M') }}">{{ comment.creation_timestamp | datetimeformat('%Y-%m-%dT%H:%M:%S') }}</span>
+          <span class="datetime" title="{{ comment.creation_timestamp | string_to_datetime('%Y-%m-%dT%H:%M') }}">{{ comment.creation_timestamp | datetimeformat('%Y-%m-%dT%H:%M:%S%z') }}</span>
           by <a href="{{ url_for('user_bp.profile', login=comment.author.login) }}">{{ comment.author.name }}</a>
           {% set origin = comment.vulnerability_lookup_origin | string %}
           {% if origin != local_instance_uuid %}


### PR DESCRIPTION
#### What does it do?

Fixes #339

Bundle and comment list pages show wrong relative timestamps (e.g. "1 hour ago" for just-created items) because the `datetimeformat` filter outputs naive ISO strings without timezone offset. Luxon's `fromISO().toRelative()` then assumes local browser time instead of UTC.

Added `%z` to the strftime format in both templates. The datetime objects are already timezone-aware (`DateTime(timezone=True)`), so `%z` outputs the correct UTC offset. This matches the pattern used in `Bundle.as_json()`.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyVulnerabilityLookup for example)?
