### PR TITLE
fix: [core] add timeout to graceful shutdown to prevent infinite loop

### DIFF
--- a/bin/shutdown.py
+++ b/bin/shutdown.py
@@ -39,6 +39,19 @@ def main() -> None:
                 time.sleep(5)
             else:
                 AbstractManager.force_kill(running)
+                for _ in range(10):
+                    time.sleep(1)
+                    if not AbstractManager.is_running():
+                        break
+                break
+        elif loop_count >= 60:
+            print("Graceful shutdown timed out after 60s, force-killing remaining processes.")
+            AbstractManager.force_kill(running)
+            for _ in range(10):
+                time.sleep(1)
+                if not AbstractManager.is_running():
+                    break
+            break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two bugs in `bin/shutdown.py` that cause `poetry run stop` to loop forever:

1. **Without `--force`**: The `while True` loop has no exit condition if services don't stop gracefully — it polls `is_running()` every second indefinitely. Adds a 60-second timeout that escalates to `force_kill()`.
2. **With `--force`**: After `force_kill()` completes, the loop continues back to the top instead of exiting. Adds `break` after kill so `--force` means "kill now and get out."

Both kill paths poll `is_running()` for up to 10 seconds after `force_kill()` to ensure processes are reaped and `service|*` PID metadata is cleaned before `stop.py` proceeds to shut down the databases.

**Note:** The `--force` path behavior changes subtly — previously it would loop back and re-check after killing, now it kills, waits for cleanup, and exits. This is intentionally more decisive: `--force` should mean immediate termination, not another polling cycle.

Fixes #268 

## Files Changed

| File | Change |
|------|--------|
| `bin/shutdown.py` | +13 lines: 60s graceful timeout, post-kill cleanup polling |

## Test Results

Tested inside the Docker Compose dev environment with 14 feeders and gunicorn running.

**Graceful shutdown (no `--force`):**

| | Before fix | After fix |
|---|-----------|-----------|
| Behavior | Infinite loop printing stale service entries every second | Polls for 60s, then escalates to `force_kill()` |
| Exit | Never | Exits after ~2m24s (5s init + 60s poll + kill + reap + DB shutdown) |

```
[...60 iterations of stale service entries...]
Graceful shutdown timed out after 60s, force-killing remaining processes.

real    2m24.227s
```

**Force shutdown (`--force`):**

| | Before fix | After fix |
|---|-----------|-----------|
| Behavior | Calls `force_kill()` on iteration 5, then loops back to top forever | Calls `force_kill()` on iteration 5, polls `is_running()` for cleanup, exits |
| Exit | Never | Exits after ~1m4s (5s init + 4×5s wait + kill + reap + DB shutdown) |

```
[...4 iterations of "Waiting a bit longer..."...]
[force_kill + is_running cleanup]

real    1m3.834s
```

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyVulnerabilityLookup for example)?
