### PR TITLE
fix: include ADP container data in CVE 5 record views

### DIFF
--- a/website/web/bootstrap.py
+++ b/website/web/bootstrap.py
@@ -284,6 +284,7 @@ application.jinja_env.filters["cvss_clean_vector"] = (
     jinja_filters.cvev5.cvss_clean_vector
 )
 application.jinja_env.filters["extract_credits"] = jinja_filters.cvev5.extract_credits
+application.jinja_env.filters["extract_ssvc"] = jinja_filters.cvev5.extract_ssvc
 
 
 application.jinja_env.filters["extract_credits_ossf"] = (

--- a/website/web/filters/cvev5.py
+++ b/website/web/filters/cvev5.py
@@ -236,14 +236,14 @@ def extract_references(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
     try:
         _add(containers.get("cna", {}).get("references", []))
     except Exception:
-        pass
+        pass  # fail-safe: ignore malformed CNA references and continue
 
     # --- ADP references (e.g. CVE Program Container, CISA ADP Vulnrichment) ---
     try:
         for adp in containers.get("adp", []) or []:
             _add(adp.get("references", []))
     except Exception:
-        pass
+        pass  # fail-safe: ignore malformed ADP references and continue
 
     # --- NVD metadata references ---
     meta = vuln.get("vulnerability-lookup:meta", {})

--- a/website/web/filters/cvev5.py
+++ b/website/web/filters/cvev5.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict
 
 import cvss  # type: ignore[import-untyped]
@@ -78,28 +79,22 @@ def extract_cvss_metrics(vuln_data: Dict[str, Any]) -> list[Dict[str, Any]]:
         ...
     ]
     """
-    all_metrics = []
+    all_metrics: list[Dict[str, Any]] = []
 
     containers = vuln_data.get("containers", {})
 
-    # 1. CNA
-    if "cna" in containers and "metrics" in containers["cna"]:
-        all_metrics = containers["cna"]["metrics"]
+    # 1. CNA + every ADP container (aggregated — an ADP provider such as
+    #    CISA may add its own metrics on top of the CNA's).
+    if "cna" in containers:
+        all_metrics += containers["cna"].get("metrics", []) or []
+    for elem in containers.get("adp", []) or []:
+        all_metrics += elem.get("metrics", []) or []
 
-    # 2. ADP
-    elif "adp" in containers:
-        for elem in containers["adp"]:
-            if "metrics" in elem:
-                all_metrics = elem["metrics"]
-                break
-
-    # 3. NVD
-    else:
+    # 2. NVD — fallback only when the CVE record itself carries no metrics.
+    if not all_metrics:
         nvd_data = vuln_data.get("vulnerability-lookup:meta", {}).get("nvd")
         if nvd_data:
             if isinstance(nvd_data, str):
-                import json
-
                 nvd_data = json.loads(nvd_data)
             metrics = nvd_data.get("cve", {}).get("metrics", {})
             all_metrics = (
@@ -111,6 +106,7 @@ def extract_cvss_metrics(vuln_data: Dict[str, Any]) -> list[Dict[str, Any]]:
 
     # Build simplified list for template
     results = []
+    seen: set[str] = set()
     for metric in all_metrics:
         vector = None
         version = None
@@ -132,8 +128,16 @@ def extract_cvss_metrics(vuln_data: Dict[str, Any]) -> list[Dict[str, Any]]:
             version = "4.0"
             score = metric["cvssV4_0"].get("baseScore")
             severity = metric["cvssV4_0"].get("baseSeverity")
+        # NVD format: vector nested under "cvssData" with its own "version"
+        elif "cvssData" in metric and "vectorString" in metric["cvssData"]:
+            cvss_data = metric["cvssData"]
+            vector = cvss_data["vectorString"]
+            version = cvss_data.get("version")
+            score = cvss_data.get("baseScore")
+            severity = cvss_data.get("baseSeverity")
 
-        if vector:
+        if vector and vector not in seen:
+            seen.add(vector)
             results.append(
                 {
                     "score": score,
@@ -157,18 +161,14 @@ def extract_cwe_list(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
     ]
     """
     results = []
+    seen: set[tuple[Any, str]] = set()
 
-    # Prefer CNA → fallback to ADP if needed.
+    # Aggregate CNA + every ADP container (an ADP provider such as CISA
+    # may add CWEs the CNA did not assign).
     containers = vuln.get("containers", {})
-    problem_sources = []
-
-    if "cna" in containers and containers["cna"].get("problemTypes"):
-        problem_sources = containers["cna"].get("problemTypes", [])
-    elif "adp" in containers:
-        for elem in containers["adp"]:
-            if elem.get("problemTypes"):
-                problem_sources = elem.get("problemTypes", [])
-                break
+    problem_sources = list(containers.get("cna", {}).get("problemTypes", []) or [])
+    for elem in containers.get("adp", []) or []:
+        problem_sources += elem.get("problemTypes", []) or []
 
     # Process problemTypes → descriptions
     for problem in problem_sources:
@@ -191,7 +191,7 @@ def extract_cwe_list(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
                 if cleaned_desc == cwe_id:
                     cleaned_desc = ""
 
-                results.append({"cwe": cwe_id, "description": cleaned_desc})
+                entry = {"cwe": cwe_id, "description": cleaned_desc}
 
             else:
                 # No cweId but description might be "CWE-79: XSS"
@@ -199,9 +199,14 @@ def extract_cwe_list(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
                     parts = cleaned_desc.split(":", 1)
                     cwe = parts[0].strip()
                     desc_part = parts[1].strip() if len(parts) > 1 else ""
-                    results.append({"cwe": cwe, "description": desc_part})
+                    entry = {"cwe": cwe, "description": desc_part}
                 else:
-                    results.append({"cwe": None, "description": cleaned_desc})
+                    entry = {"cwe": None, "description": cleaned_desc}
+
+            key = (entry["cwe"], entry["description"])
+            if key not in seen:
+                seen.add(key)
+                results.append(entry)
 
     return results
 
@@ -213,18 +218,30 @@ def extract_references(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
     """
 
     # Result container
-    refs = []
+    refs: list[Dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _add(entries: Any) -> None:
+        """Append unique references (by URL) from a list of CVE reference objects."""
+        for ref in entries or []:
+            url = ref.get("url")
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            refs.append({"url": url, "tags": ref.get("tags", [])})
+
+    containers = vuln.get("containers", {})
 
     # --- CNA references ---
     try:
-        cna = vuln.get("containers", {}).get("cna", {})
-        entries = cna.get("references", [])
-        for ref in entries:
-            url = ref.get("url")
-            if not url:
-                continue
-            tags = ref.get("tags", [])
-            refs.append({"url": url, "tags": tags})
+        _add(containers.get("cna", {}).get("references", []))
+    except Exception:
+        pass
+
+    # --- ADP references (e.g. CVE Program Container, CISA ADP Vulnrichment) ---
+    try:
+        for adp in containers.get("adp", []) or []:
+            _add(adp.get("references", []))
     except Exception:
         pass
 
@@ -234,17 +251,8 @@ def extract_references(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
         try:
             nvd = meta["nvd"]
             # If nvd is serialized, the template should already have used str_to_obj
-            if isinstance(nvd, str):
-                # Guard: avoid throwing inside filter
-                return refs
-            entries = nvd.get("cve", {}).get("references", [])
-
-            for ref in entries:
-                url = ref.get("url")
-                if not url:
-                    continue
-                tags = ref.get("tags", [])
-                refs.append({"url": url, "tags": tags})
+            if not isinstance(nvd, str):
+                _add(nvd.get("cve", {}).get("references", []))
         except Exception:
             pass  # fail-safe — return what we have so far
 
@@ -253,25 +261,31 @@ def extract_references(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
 
 def extract_impacted_products(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
     """
-    Extract impacted products from CNA → affected.
+    Extract impacted products from CNA and ADP containers (→ affected).
     Returns a list of dicts with vendor, product, versions, cpes.
     """
 
-    products = []
+    products: list[Dict[str, Any]] = []
+    seen: set[str] = set()
+    invalid = {"n/a", "n / a"}
 
-    try:
-        cna = vuln.get("containers", {}).get("cna", {})
-        affected = cna.get("affected", []) or []
-
-        for entry in affected:
+    def _add(affected: Any) -> None:
+        """Append unique impacted products from an ``affected`` list."""
+        for entry in affected or []:
             vendor = entry.get("vendor") or ""
             product = entry.get("product") or ""
             versions = entry.get("versions", [])
             cpes = entry.get("cpes", [])
 
-            invalid = {"n/a", "n / a"}
             if vendor in invalid and product in invalid:
                 continue
+
+            key = json.dumps(
+                [vendor, product, versions, cpes], sort_keys=True
+            )
+            if key in seen:
+                continue
+            seen.add(key)
 
             products.append(
                 {
@@ -281,6 +295,12 @@ def extract_impacted_products(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
                     "cpes": cpes,
                 }
             )
+
+    try:
+        containers = vuln.get("containers", {})
+        _add(containers.get("cna", {}).get("affected", []))
+        for adp in containers.get("adp", []) or []:
+            _add(adp.get("affected", []))
     except Exception:
         return []
 
@@ -372,3 +392,56 @@ def extract_credits(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
 
     except Exception:
         return []
+
+
+def extract_ssvc(vuln: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """
+    Extract SSVC (Stakeholder-Specific Vulnerability Categorization) decisions
+    from ADP containers (e.g. CISA ADP Vulnrichment).
+
+    Returns a list of dicts:
+    [
+        {
+            "role": "CISA Coordinator",
+            "version": "2.0.3",
+            "timestamp": "2024-04-02T04:00:23.138684Z",
+            "options": [
+                {"label": "Exploitation", "value": "none"},
+                {"label": "Automatable", "value": "yes"},
+                {"label": "Technical Impact", "value": "total"},
+            ],
+        },
+        ...
+    ]
+    """
+    results: list[Dict[str, Any]] = []
+
+    try:
+        containers = vuln.get("containers", {})
+        for adp in containers.get("adp", []) or []:
+            for metric in adp.get("metrics", []) or []:
+                other = metric.get("other", {})
+                if other.get("type") != "ssvc":
+                    continue
+                content = other.get("content", {}) or {}
+
+                options = []
+                for opt in content.get("options", []) or []:
+                    for label, value in opt.items():
+                        options.append({"label": label, "value": value})
+
+                if not options:
+                    continue
+
+                results.append(
+                    {
+                        "role": content.get("role"),
+                        "version": content.get("version"),
+                        "timestamp": content.get("timestamp"),
+                        "options": options,
+                    }
+                )
+    except Exception:
+        return []
+
+    return results

--- a/website/web/templates/vulnerability_templates.html
+++ b/website/web/templates/vulnerability_templates.html
@@ -870,6 +870,34 @@
         </div>
 
 
+        <!-- SSVC -->
+        {% set ssvc_list = vulnerability_data | extract_ssvc %}
+        {% if ssvc_list %}
+        <div class="row mb-2">
+          <div class="col-md-2 fw-bold" tabindex="0" style="cursor: pointer; text-decoration: underline dotted;" data-bs-toggle="popover"
+              data-bs-placement="left" data-bs-trigger="focus" data-bs-html="true"
+              title="SSVC"
+              data-bs-content='Stakeholder-Specific Vulnerability Categorization (SSVC) is a decision-tree-based prioritization method. <a href="https://www.cisa.gov/ssvc" rel="noreferrer" target="_blank">About SSVC</a>'>
+            SSVC <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/></svg>
+          </div>
+          <div class="col">
+            <div class="d-flex flex-wrap gap-2">
+              {% for ssvc in ssvc_list %}
+                <div class="border rounded p-2">
+                  {% for opt in ssvc.options %}
+                    <span class="badge bg-secondary rounded-pill m-1">{{ opt.label }}: {{ opt.value }}</span>
+                  {% endfor %}
+                  {% if ssvc.role %}
+                    <div class="text-muted small mt-1">{{ ssvc.role }}{% if ssvc.version %} (v{{ ssvc.version }}){% endif %}</div>
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+        {% endif %}
+
+
         <!-- CWEs -->
         {% set cwe_list = vulnerability_data | extract_cwe_list %}
         {% if cwe_list %}


### PR DESCRIPTION
## Problem

The Jinja macro `cvelistv5_view` was not displaying references from the CISA ADP container (e.g. for CVE-2024-3094, where the CNA only supplies 4 references while the *CVE Program Container* ADP holds ~55 `x_transferred` ones).

Investigating revealed the same blind spot across **all four** CVE 5 extraction filters in `website/web/filters/cvev5.py`: they read only the `cna` container (treating `adp` as a mere fallback), so any references, impacted products, CWEs, or CVSS metrics contributed by ADP providers (CISA ADP Vulnrichment, the CVE Program Container) were silently dropped whenever the CNA had data.

## Changes

All four filters now aggregate across the CNA **and every ADP container**, with de-duplication:

| Filter | Before | After |
|---|---|---|
| `extract_references` | CNA + NVD | CNA + **all ADP** + NVD, de-duped by URL |
| `extract_impacted_products` | CNA only | CNA + **all ADP**, de-duped by (vendor, product, versions, cpes) |
| `extract_cvss_metrics` | CNA *else* first ADP *else* NVD | CNA + **all ADP** aggregated, NVD still fallback-only, de-duped by vector |
| `extract_cwe_list` | CNA *else* first ADP | CNA + **all ADP** aggregated, de-duped by (cwe, description) |

Additionally:

- **NVD-format CVSS fallback fix**: the NVD branch collected NVD metric objects but the loop only understood the CVE 5 nesting (`cvssV3_1` etc.), so the fallback never produced output. It now reads the vector from `cvssData` (using its own `version`).
- **SSVC rendering**: new `extract_ssvc` filter + a new "SSVC" row in `cvelistv5_view` surfaces CISA SSVC decision points (Exploitation / Automatable / Technical Impact), which were not displayed at all.

## Verification

- `mypy website/web/filters/cvev5.py` — clean.
- Unit-tested each filter against the CVE-2024-3094 example data (ADP references/products now included, duplicates collapsed, NVD CVSS fallback returns the deduped 9.8 CRITICAL, SSVC returns the three decision points).
- Jinja template parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)