### PR TITLE
new: [api] browse endpoints exposing per-vendor/product last-change dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Vulnerability-Lookup Changelog
 
 ### What's New
 
-- new: [api] Browse endpoints exposing the date of the last vulnerability change per vendor and product (`GET /api/browse/vendors` and `GET /api/browse/vendors/<vendor>/products`), so clients can poll only the vendors/products that actually changed since their last call instead of fanning out over every product. The timestamps are maintained at import time by every feeder that populates the vendor/product index and backfilled by the reindex tool ([#255](https://github.com/vulnerability-lookup/vulnerability-lookup/issues/255), [#422](https://github.com/vulnerability-lookup/vulnerability-lookup/pull/422)).
+- new: [api] Browse endpoints exposing the date of the last vulnerability change per vendor and product (`GET /api/browse/vendors` and `GET /api/browse/vendors/<vendor>/products`), so clients can poll only the vendors/products that actually changed since their last call instead of fanning out over every product. The timestamps are maintained at import time by every feeder that populates the vendor/product index and backfilled by the reindex tool. The last-change dates live in dedicated sorted sets (`vendors:updated`, `<vendor>:products:updated`), so a `since=` query costs a single `ZRANGE … WITHSCORES` plus an in-memory sort regardless of how many CVEs sit behind each vendor — no caching layer is required ([#255](https://github.com/vulnerability-lookup/vulnerability-lookup/issues/255), [#422](https://github.com/vulnerability-lookup/vulnerability-lookup/pull/422)).
   [98a6b02a](https://github.com/vulnerability-lookup/vulnerability-lookup/commit/98a6b02a)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@ Vulnerability-Lookup Changelog
 ==============================
 
 
+## Unreleased
+
+### What's New
+
+- new: [api] Browse endpoints exposing the date of the last vulnerability change per vendor and product (`GET /api/browse/vendors` and `GET /api/browse/vendors/<vendor>/products`), so clients can poll only the vendors/products that actually changed since their last call instead of fanning out over every product. The timestamps are maintained at import time by every feeder that populates the vendor/product index and backfilled by the reindex tool ([#255](https://github.com/vulnerability-lookup/vulnerability-lookup/issues/255), [#422](https://github.com/vulnerability-lookup/vulnerability-lookup/pull/422)).
+  [98a6b02a](https://github.com/vulnerability-lookup/vulnerability-lookup/commit/98a6b02a)
+
+### Changes
+
+- chg: [api] Signpost the legacy plain-list browse endpoints (`/api/browse/`, `/api/browse/<vendor>`, `/api/vulnerability/browse/`) as deprecated via `Deprecation`/`Sunset`/`Link` headers and the OpenAPI docs, in favor of the new metadata-aware endpoints. Behavior and response shape are unchanged ([#255](https://github.com/vulnerability-lookup/vulnerability-lookup/issues/255)).
+  [73fffcff](https://github.com/vulnerability-lookup/vulnerability-lookup/commit/73fffcff)
+
+### Fixes
+
+- fix: [api] Percent-encode the user-controlled vendor segment before placing it in the deprecation `Link` header, preventing header injection.
+  [2cac2882](https://github.com/vulnerability-lookup/vulnerability-lookup/commit/2cac2882)
+
+
 ## 5.1.0 (2026-06-11)
 
 ### What's New

--- a/bin/index_vulnerabilities.py
+++ b/bin/index_vulnerabilities.py
@@ -29,6 +29,8 @@ less — otherwise the rebuild would invent keys the feeder never refreshes
 * vendor/product sets ...... ``vendors`` / ``products`` / ``{vendor}:products`` /
                              ``{vendor}:vulnerabilities`` / ``{vendor}:{product}:vulnerabilities`` /
                              ``product:{product}:vulnerabilities``
+* vendor/product freshness . ``vendors:updated`` / ``{vendor}:products:updated``
+                             (zsets scored by the most recent change, ZADD GT)
 * assigner sets ............ ``assigners`` / ``assigner:{a}:vulnerabilities`` /
                              ``{vuln}:assigner`` / ``assignerOrgId:{id}:vulnerabilities`` /
                              ``adp:shortName:{n}``
@@ -69,7 +71,7 @@ from typing import Any, Callable
 import orjson
 
 from vulnerabilitylookup import VulnerabilityLookup
-from vulnerabilitylookup.helpers import fromisoformat_wrapper
+from vulnerabilitylookup.helpers import fromisoformat_wrapper, record_vendor_product_change
 
 vl = VulnerabilityLookup()
 
@@ -169,7 +171,7 @@ def reset_globals() -> None:
     rebuild, so wiping them would make those sources disappear. Stale members of
     the ``index*`` zsets are harmless (readers skip ids whose blob is gone).
     """
-    for key in ("vendors", "products", "assigners"):
+    for key in ("vendors", "products", "assigners", "vendors:updated"):
         if vl.storage.exists(key):
             vl.storage.delete(key)
     for pattern in (
@@ -177,6 +179,7 @@ def reset_globals() -> None:
         "*:vulnerabilities:counted",
         "*:vulnerabilities:counted:*",
         "*:products",
+        "*:products:updated",
         "product:*:vulnerabilities",
         "assigner:*:vulnerabilities",
         "assignerOrgId:*:vulnerabilities",
@@ -439,6 +442,8 @@ def reindex_cvelistv5(source: str = "cvelistv5") -> None:
             p.sadd(f"product:{product}:vulnerabilities", vid)
             p.sadd(f"{vendor}:vulnerabilities", vid)
             p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+            if updated:
+                record_vendor_product_change(p, vendor, product, updated.timestamp())
             if period and vid not in vendor_counted[vendor]:
                 vendor_counted[vendor].add(vid)
                 y, m = period
@@ -582,6 +587,10 @@ def reindex_gna(sources: list[str]) -> None:
                 p.sadd(f"product:{product}:vulnerabilities", vid)
                 p.sadd(f"{vendor}:vulnerabilities", vid)
                 p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+                if updated:
+                    record_vendor_product_change(
+                        p, vendor, product, updated.timestamp()
+                    )
                 if published and vid not in vendor_counted[vendor]:
                     vendor_counted[vendor].add(vid)
                     y, m = _periods(published)
@@ -720,6 +729,8 @@ def reindex_osv(source: str) -> None:
             p.sadd(f"product:{product}:vulnerabilities", vid)
             p.sadd(f"{vendor}:vulnerabilities", vid)
             p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+            if updated:
+                record_vendor_product_change(p, vendor, product, updated.timestamp())
         b.maybe_flush()
         p = b.pipe
     b.flush_indexes()
@@ -800,6 +811,10 @@ def reindex_fkie_nvd(source: str = "fkie_nvd") -> None:
                         p.sadd(f"{vendor}:products", product)
                         p.sadd(f"{vendor}:vulnerabilities", vid)
                         p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+                        if updated:
+                            record_vendor_product_change(
+                                p, vendor, product, updated.timestamp()
+                            )
                     else:
                         p.srem(f"{vendor}:vulnerabilities", vid)
                         p.srem(f"{vendor}:{product}:vulnerabilities", vid)
@@ -881,6 +896,11 @@ def rebuild_nvd_vendor_sets(source: str = "nvd") -> None:
         except orjson.JSONDecodeError:
             continue
         cve_obj = vuln.get("cve", vuln)
+        updated = _safe_dt(
+            cve_obj.get("lastModified")
+            or cve_obj.get("lastModifiedDate")
+            or cve_obj.get("published")
+        )
         for config in cve_obj.get("configurations", []) or []:
             for node in config.get("nodes", []):
                 for cpe_match in node.get("cpeMatch", []):
@@ -897,6 +917,10 @@ def rebuild_nvd_vendor_sets(source: str = "nvd") -> None:
                     p.sadd(f"{vendor}:products", product)
                     p.sadd(f"{vendor}:vulnerabilities", cve_id)
                     p.sadd(f"{vendor}:{product}:vulnerabilities", cve_id)
+                    if updated:
+                        record_vendor_product_change(
+                            p, vendor, product, updated.timestamp()
+                        )
                     added += 1
                     pending += 1
         if pending >= 1000:
@@ -984,6 +1008,8 @@ def reindex_certfr(source: str) -> None:
             p.sadd(f"{vendor}:products", product)
             p.sadd(f"{vendor}:vulnerabilities", vid)
             p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+            if updated:
+                record_vendor_product_change(p, vendor, product, updated.timestamp())
         b.maybe_flush()
         p = b.pipe
     b.flush_indexes()
@@ -1037,6 +1063,8 @@ def reindex_jvndb(source: str = "jvndb") -> None:
             p.sadd(f"{vendor}:products", product)
             p.sadd(f"{vendor}:vulnerabilities", vid)
             p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+            if updated:
+                record_vendor_product_change(p, vendor, product, updated.timestamp())
         b.maybe_flush()
         p = b.pipe
     b.flush_indexes()
@@ -1134,6 +1162,10 @@ def reindex_variot(source: str = "variot") -> None:
             if product:
                 p.sadd(f"{vendor}:products", product)
                 p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+            if updated:
+                record_vendor_product_change(
+                    p, vendor, product or None, updated.timestamp()
+                )
         b.maybe_flush()
         p = b.pipe
     b.flush_indexes()
@@ -1217,6 +1249,8 @@ def reindex_moksha(source: str = "moksha") -> None:
             p.sadd(f"{vendor}:products", product)
             p.sadd(f"{vendor}:vulnerabilities", vid)
             p.sadd(f"{vendor}:{product}:vulnerabilities", vid)
+            if updated:
+                record_vendor_product_change(p, vendor, product, updated.timestamp())
         b.maybe_flush()
         p = b.pipe
     b.flush_indexes()

--- a/poetry.lock
+++ b/poetry.lock
@@ -665,14 +665,14 @@ dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools ; python_version
 
 [[package]]
 name = "distlib"
-version = "0.4.2"
+version = "0.4.3"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
 groups = ["dev"]
 files = [
-    {file = "distlib-0.4.2-py2.py3-none-any.whl", hash = "sha256:ca4cb11e5d746b5ec13c199cbf19ae27a241f89702b54e153a74332955446067"},
-    {file = "distlib-0.4.2.tar.gz", hash = "sha256:baeb401c90f27acd15c4861ae0847d1e731c27ac3dbf4210643ba61fa1e813db"},
+    {file = "distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"},
+    {file = "distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"},
 ]
 
 [[package]]
@@ -771,14 +771,14 @@ sgmllib3k = "*"
 
 [[package]]
 name = "filelock"
-version = "3.29.3"
+version = "3.29.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d"},
-    {file = "filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84"},
+    {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
+    {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
 ]
 
 [[package]]
@@ -2972,14 +2972,14 @@ fetch-lists = ["requests (>=2.32.5)"]
 
 [[package]]
 name = "pyotp"
-version = "2.9.0"
+version = "2.10.0"
 description = "Python One Time Password Library"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612"},
-    {file = "pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63"},
+    {file = "pyotp-2.10.0-py3-none-any.whl", hash = "sha256:1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c"},
+    {file = "pyotp-2.10.0.tar.gz", hash = "sha256:d01e9703443616b03c57c700b5cbffd56a1f929c1b0f8f03131bc78c1fca9d3f"},
 ]
 
 [package.extras]
@@ -3015,14 +3015,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
+    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
 ]
 
 [package.dependencies]
@@ -3071,14 +3071,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.2"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da"},
-    {file = "python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3"},
+    {file = "python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500"},
+    {file = "python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690"},
 ]
 
 [package.dependencies]
@@ -4428,21 +4428,21 @@ ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"
 
 [[package]]
 name = "virtualenv"
-version = "21.4.2"
+version = "21.5.0"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae"},
-    {file = "virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c"},
+    {file = "virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e"},
+    {file = "virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1.4"
+python-discovery = ">=1.4.2"
 
 [[package]]
 name = "wcwidth"

--- a/vulnerabilitylookup/feeders/certfr.py
+++ b/vulnerabilitylookup/feeders/certfr.py
@@ -11,6 +11,7 @@ import orjson
 import requests
 
 
+from ..helpers import record_vendor_product_change
 from .abstract_feeder import AbstractFeeder
 
 
@@ -107,6 +108,7 @@ class CertFr(AbstractFeeder):
                 p.sadd(f"{vendor}:products", product)
                 p.sadd(f"{vendor}:vulnerabilities", vuln_id)
                 p.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                record_vendor_product_change(p, vendor, product, last_modified_ts)
 
             # batch execution
             if len(updated_index) >= 100:

--- a/vulnerabilitylookup/feeders/cvelistv5.py
+++ b/vulnerabilitylookup/feeders/cvelistv5.py
@@ -9,7 +9,7 @@ from typing import Callable
 import orjson
 from redis.exceptions import ResponseError
 
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 from .abstract_feeder import AbstractFeeder
 
 
@@ -237,6 +237,9 @@ class CVEListV5(AbstractFeeder):
                             p.sadd(f"product:{product}:vulnerabilities", vuln_id)
                             p.sadd(f"{vendor}:vulnerabilities", vuln_id)
                             p.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                            record_vendor_product_change(
+                                p, vendor, product, updated.timestamp()
+                            )
 
                             # --- Vendor ranking (unique vendor–CVE only) ---
                             if published:

--- a/vulnerabilitylookup/feeders/fkie_nvd.py
+++ b/vulnerabilitylookup/feeders/fkie_nvd.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 import orjson
 
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 
 from .abstract_feeder import AbstractFeeder
 
@@ -95,6 +95,9 @@ class FkieNVD(AbstractFeeder):
                                 p.sadd(f'{vendor}:products', product)
                                 p.sadd(f'{vendor}:vulnerabilities', vuln_id)
                                 p.sadd(f'{vendor}:{product}:vulnerabilities', vuln_id)
+                                record_vendor_product_change(
+                                    p, vendor, product, index_fkie[vuln_id]
+                                )
                             else:
                                 # if vulnerable is false, do not add the the vendor/product in the vulnerabilities
                                 # and remove the vuln_id if it's there

--- a/vulnerabilitylookup/feeders/gcve_vl.py
+++ b/vulnerabilitylookup/feeders/gcve_vl.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 
 from vulnerabilitylookup import __user_agent__
 from vulnerabilitylookup.feeders.abstract_feeder import AbstractFeeder
-from vulnerabilitylookup.helpers import fromisoformat_wrapper
+from vulnerabilitylookup.helpers import fromisoformat_wrapper, record_vendor_product_change
 from website.lib.gcve_utils import get_by_id
 from website.models import Organization
 from website.web.bootstrap import application, db
@@ -204,6 +204,9 @@ class GCVE(AbstractFeeder):
                                 p.sadd(f"product:{product}:vulnerabilities", vuln_id)
                                 p.sadd(f"{vendor}:vulnerabilities", vuln_id)
                                 p.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                                record_vendor_product_change(
+                                    p, vendor, product, updated.timestamp()
+                                )
 
                                 # --- vendor ranking (unique vendor↔vuln only) ---
                                 # Scoped to this source so it never collides with

--- a/vulnerabilitylookup/feeders/jvndb.py
+++ b/vulnerabilitylookup/feeders/jvndb.py
@@ -13,7 +13,7 @@ import orjson
 import requests
 import xmltodict
 
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 
 from .abstract_feeder import AbstractFeeder
 
@@ -129,6 +129,7 @@ class JVNDB(AbstractFeeder):
                     pipeline.sadd(f"{vendor}:products", product)
                     pipeline.sadd(f"{vendor}:vulnerabilities", vuln_id)
                     pipeline.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                    record_vendor_product_change(pipeline, vendor, product, last_modified.timestamp())
 
                 # Store & publish
                 vuln_bytes = orjson.dumps(vuln)

--- a/vulnerabilitylookup/feeders/moksha.py
+++ b/vulnerabilitylookup/feeders/moksha.py
@@ -9,7 +9,7 @@ from typing import Callable
 
 import orjson
 
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 
 from .abstract_feeder import AbstractFeeder
 
@@ -136,6 +136,7 @@ class Moksha(AbstractFeeder):
                 p.sadd(f"{vendor}:products", product)
                 p.sadd(f"{vendor}:vulnerabilities", vuln_id)
                 p.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                record_vendor_product_change(p, vendor, product, last_modified_ts)
 
             # batch execution
             if len(index_moksha) >= 100:

--- a/vulnerabilitylookup/feeders/nvd.py
+++ b/vulnerabilitylookup/feeders/nvd.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import orjson
 from redis.exceptions import ResponseError
 
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 
 from .abstract_feeder import AbstractFeeder
 
@@ -212,6 +212,9 @@ class NVD(AbstractFeeder):
                                         p.sadd(f"{vendor}:vulnerabilities", cve_id)
                                         p.sadd(
                                             f"{vendor}:{product}:vulnerabilities", cve_id
+                                        )
+                                        record_vendor_product_change(
+                                            p, vendor, product, lastmod_ts
                                         )
                                     else:
                                         # if vulnerable is false, do not add the the vendor/product in the vulnerabilities

--- a/vulnerabilitylookup/feeders/osv_parser.py
+++ b/vulnerabilitylookup/feeders/osv_parser.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Callable
 
 from ..default import VulnerabilityLookupException
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 
 from .abstract_feeder import AbstractFeeder
 
@@ -137,6 +137,10 @@ class OSVParser(AbstractFeeder):
                             p.sadd(f"product:{product}:vulnerabilities", vuln_id)
                             p.sadd(f"{vendor}:vulnerabilities", vuln_id)
                             p.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                            if updated:
+                                record_vendor_product_change(
+                                    p, vendor, product, updated.timestamp()
+                                )
 
             # Execute pipeline every 200 entries to avoid huge batches
             if len(updated_index) >= 200:

--- a/vulnerabilitylookup/feeders/variot.py
+++ b/vulnerabilitylookup/feeders/variot.py
@@ -7,7 +7,7 @@ from typing import Callable
 import orjson
 from redis.exceptions import ResponseError
 
-from ..helpers import fromisoformat_wrapper
+from ..helpers import fromisoformat_wrapper, record_vendor_product_change
 
 from .abstract_feeder import AbstractFeeder
 
@@ -74,6 +74,9 @@ class VARIoTDB(AbstractFeeder):
                         vendor = vendor.strip().lower()
                         p.sadd("vendors", vendor)
                         p.sadd(f"{vendor}:vulnerabilities", vuln_id)
+                        record_vendor_product_change(
+                            p, vendor, None, last_modified.timestamp()
+                        )
 
                         # Vendor ranking (unique vendor↔vuln only). The guard set
                         # is scoped to this source so it never collides with
@@ -103,6 +106,9 @@ class VARIoTDB(AbstractFeeder):
                             product = product.strip().lower()
                             p.sadd(f"{vendor}:products", product)
                             p.sadd(f"{vendor}:{product}:vulnerabilities", vuln_id)
+                            record_vendor_product_change(
+                                p, vendor, product, last_modified.timestamp()
+                            )
 
             # --- Links to CVE if present ---
             if "cve" in vuln and vuln["cve"]:

--- a/vulnerabilitylookup/helpers.py
+++ b/vulnerabilitylookup/helpers.py
@@ -6,6 +6,9 @@ import sys
 from datetime import datetime, timezone
 from typing import Dict
 
+from redis import Redis
+from redis.client import Pipeline
+
 from .default import get_homedir
 
 
@@ -35,6 +38,22 @@ def fromisoformat_wrapper(date_iso: str | datetime, /) -> datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
+
+
+def record_vendor_product_change(
+    pipe: Redis | Pipeline,  # type: ignore[type-arg]
+    vendor: str,
+    product: str | None,
+    timestamp: float,
+) -> None:
+    """Track the most recent vulnerability change per vendor and per (vendor, product).
+
+    ZADD GT only moves scores forward, so reimports and out-of-order imports
+    never push a last-change date back in time.
+    """
+    pipe.zadd("vendors:updated", {vendor: timestamp}, gt=True)
+    if product:
+        pipe.zadd(f"{vendor}:products:updated", {product: timestamp}, gt=True)
 
 
 def get_config_feeder(feeder_name: str) -> Dict[str, str]:

--- a/vulnerabilitylookup/vulnerabilitylookup.py
+++ b/vulnerabilitylookup/vulnerabilitylookup.py
@@ -373,6 +373,74 @@ class VulnerabilityLookup:
         _v = vendor.strip().lower()
         return self.storage.smembers(f"{_v}:products")
 
+    @staticmethod
+    def _filter_last_changes(
+        names: Iterable[str],
+        last_changes: dict[str, float],
+        q: str,
+        since: float | None,
+        page: int,
+        per_page: int,
+    ) -> tuple[int, list[dict[str, Any]]]:
+        """Merge a name set with its last-change zset scores, filter, sort and paginate.
+
+        Entries are sorted by most recent change first; entries without a
+        recorded timestamp come last with a None last_change. A ``since``
+        filter excludes them, as they cannot match a time filter.
+        """
+        entries: list[dict[str, Any]] = []
+        for name in names:
+            if q and q not in name:
+                continue
+            ts = last_changes.get(name)
+            if since is not None and (ts is None or ts < since):
+                continue
+            entries.append({"name": name, "last_change": ts})
+        entries.sort(
+            key=lambda e: (
+                e["last_change"] is None,
+                -(e["last_change"] or 0),
+                e["name"],
+            )
+        )
+        total = len(entries)
+        start = (page - 1) * per_page
+        return total, entries[start : start + per_page]
+
+    def get_vendors_with_last_change(
+        self,
+        q: str = "",
+        since: float | None = None,
+        page: int = 1,
+        per_page: int = 100,
+    ) -> tuple[int, list[dict[str, Any]]]:
+        """Return vendors enriched with the timestamp of their most recent
+        vulnerability change."""
+        last_changes: dict[str, float] = dict(
+            self.storage.zrange("vendors:updated", 0, -1, withscores=True)
+        )
+        return self._filter_last_changes(
+            self.get_vendors(), last_changes, q, since, page, per_page
+        )
+
+    def get_vendor_products_with_last_change(
+        self,
+        vendor: str,
+        q: str = "",
+        since: float | None = None,
+        page: int = 1,
+        per_page: int = 100,
+    ) -> tuple[int, list[dict[str, Any]]]:
+        """Return the products of a vendor enriched with the timestamp of
+        their most recent vulnerability change."""
+        _v = vendor.strip().lower()
+        last_changes: dict[str, float] = dict(
+            self.storage.zrange(f"{_v}:products:updated", 0, -1, withscores=True)
+        )
+        return self._filter_last_changes(
+            self.get_vendor_products(_v), last_changes, q, since, page, per_page
+        )
+
     def get_vendor_vulnerabilities(
         self,
         vendor: str,

--- a/website/web/api/v1/browse.py
+++ b/website/web/api/v1/browse.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import quote
 
 from flask import request
 from flask_restx import (  # type: ignore[import-untyped]
@@ -72,10 +73,13 @@ class VendorProducts(Resource):  # type: ignore[misc]
 
         Deprecated in favor of /api/browse/vendors/<vendor>/products.
         """
+        # quote the user-controlled segment so it cannot break out of the
+        # <...> URI-reference in the Link header (header injection).
+        successor = f"/api/browse/vendors/{quote(vendor, safe='')}/products"
         return (
             list(vulnerabilitylookup.get_vendor_products(vendor)),
             200,
-            _deprecation_headers(f"/api/browse/vendors/{vendor}/products"),
+            _deprecation_headers(successor),
         )
 
 

--- a/website/web/api/v1/browse.py
+++ b/website/web/api/v1/browse.py
@@ -1,12 +1,19 @@
 import logging
+from datetime import datetime, timezone
+from typing import Any
 
 from flask import request
 from flask_restx import (  # type: ignore[import-untyped]
     Namespace,
     Resource,
+    abort,
+    reqparse,
 )
 
+from vulnerabilitylookup.helpers import fromisoformat_wrapper
 from website.web.bootstrap import vulnerabilitylookup
+
+from .decorator_helpers import typed
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +40,98 @@ class VendorProducts(Resource):  # type: ignore[misc]
     def get(self, vendor: str) -> list[str]:
         """Get the known products for a vendor."""
         return list(vulnerabilitylookup.get_vendor_products(vendor))
+
+
+last_change_parser = reqparse.RequestParser()
+last_change_parser.add_argument(
+    "q",
+    type=str,
+    required=False,
+    help="Case-insensitive substring filter on the name.",
+)
+last_change_parser.add_argument(
+    "since",
+    type=str,
+    required=False,
+    help="Only return entries whose last change is at or after this date "
+    "(ISO 8601 datetime or Unix timestamp). Entries without a known last "
+    "change date are excluded.",
+)
+last_change_parser.add_argument(
+    "page",
+    type=int,
+    default=1,
+    help="Number of the page.",
+)
+last_change_parser.add_argument(
+    "per_page",
+    type=int,
+    default=100,
+    help="Maximum number of elements to return (capped at 1000).",
+)
+
+
+def _parse_last_change_args() -> tuple[str, float | None, int, int]:
+    args = last_change_parser.parse_args()
+    q = (args.get("q") or "").strip().lower()
+    since: float | None = None
+    if args.get("since"):
+        raw_since = args["since"].strip()
+        try:
+            since = float(raw_since)
+        except ValueError:
+            try:
+                since = fromisoformat_wrapper(raw_since).timestamp()
+            except ValueError:
+                abort(400, "Invalid 'since' value: expected an ISO 8601 datetime or a Unix timestamp.")
+    page = max(args.get("page") or 1, 1)
+    per_page = min(max(args.get("per_page") or 100, 1), 1000)
+    return q, since, page, per_page
+
+
+def _format_last_change_response(
+    total: int, entries: list[dict[str, Any]], page: int, per_page: int
+) -> dict[str, Any]:
+    for entry in entries:
+        if entry["last_change"] is not None:
+            entry["last_change"] = datetime.fromtimestamp(
+                entry["last_change"], tz=timezone.utc
+            ).isoformat()
+    return {
+        "metadata": {"count": total, "page": page, "per_page": per_page},
+        "data": entries,
+    }
+
+
+@browse_ns.route("/vendors")
+@browse_ns.doc(
+    description="Get the known vendors with the date of their most recent "
+    "vulnerability change, most recently changed first. Vendors without a "
+    "known last change date are listed last with a null last_change.",
+)
+class VendorsLastChange(Resource):  # type: ignore[misc]
+    @typed(browse_ns.expect(last_change_parser))
+    def get(self) -> dict[str, Any]:
+        """Get the known vendors with their last vulnerability change date."""
+        q, since, page, per_page = _parse_last_change_args()
+        total, entries = vulnerabilitylookup.get_vendors_with_last_change(
+            q, since, page, per_page
+        )
+        return _format_last_change_response(total, entries, page, per_page)
+
+
+@browse_ns.route("/vendors/<string:vendor>/products")
+@browse_ns.doc(
+    description="Get the known products of a vendor with the date of their "
+    "most recent vulnerability change, most recently changed first. Products "
+    "without a known last change date are listed last with a null last_change.",
+)
+class VendorProductsLastChange(Resource):  # type: ignore[misc]
+    @typed(browse_ns.expect(last_change_parser))
+    def get(self, vendor: str) -> dict[str, Any]:
+        """Get the products of a vendor with their last vulnerability change date."""
+        q, since, page, per_page = _parse_last_change_args()
+        total, entries = vulnerabilitylookup.get_vendor_products_with_last_change(
+            vendor, q, since, page, per_page
+        )
+        return _format_last_change_response(total, entries, page, per_page)

--- a/website/web/api/v1/browse.py
+++ b/website/web/api/v1/browse.py
@@ -21,25 +21,62 @@ browse_ns = Namespace(
     "browse", description="Endpoints for accessing vendor and product information."
 )
 
+# RFC 8594 deprecation signposting for the legacy plain-list browse endpoints.
+# They return a bare array of names and are superseded by the metadata-aware
+# /api/browse/vendors and /api/browse/vendors/<vendor>/products endpoints.
+# Per the discussion in issue #255 they keep working with a deprecation notice
+# and a sunset window, after which the legacy queries are redirected to the new
+# endpoints. Adjust LEGACY_BROWSE_SUNSET to ~6 months after the release that
+# ships the replacement.
+LEGACY_BROWSE_SUNSET = "Mon, 14 Dec 2026 00:00:00 GMT"
+DEPRECATION_LINK = (
+    "https://github.com/vulnerability-lookup/vulnerability-lookup/issues/255"
+)
+
+
+def _deprecation_headers(successor: str) -> dict[str, str]:
+    """Build RFC 8594 / draft-deprecation headers pointing to the successor."""
+    return {
+        "Deprecation": "true",
+        "Sunset": LEGACY_BROWSE_SUNSET,
+        "Link": f'<{successor}>; rel="successor-version", '
+        f'<{DEPRECATION_LINK}>; rel="deprecation"',
+    }
+
 
 @browse_ns.route("/")
-@browse_ns.doc(description="Get the known vendors.")
+@browse_ns.doc(
+    description="Deprecated: use GET /api/browse/vendors instead. "
+    "Get the known vendors.",
+    deprecated=True,
+)
 class Vendors(Resource):  # type: ignore[misc]
-    def get(self) -> list[str]:
-        """Get the known vendors."""
+    def get(self) -> tuple[list[str], int, dict[str, str]]:
+        """Get the known vendors. Deprecated in favor of /api/browse/vendors."""
         vendor = request.args.get("vendor", "").lower()
         vendors = list(vulnerabilitylookup.get_vendors())
         if vendor and len(vendor) >= 3:
             vendors = [elem for elem in vendors if vendor in elem]
-        return vendors
+        return vendors, 200, _deprecation_headers("/api/browse/vendors")
 
 
 @browse_ns.route("/<string:vendor>")
-@browse_ns.doc(description="Get the known products for a vendor.")
+@browse_ns.doc(
+    description="Deprecated: use GET /api/browse/vendors/<vendor>/products instead. "
+    "Get the known products for a vendor.",
+    deprecated=True,
+)
 class VendorProducts(Resource):  # type: ignore[misc]
-    def get(self, vendor: str) -> list[str]:
-        """Get the known products for a vendor."""
-        return list(vulnerabilitylookup.get_vendor_products(vendor))
+    def get(self, vendor: str) -> tuple[list[str], int, dict[str, str]]:
+        """Get the known products for a vendor.
+
+        Deprecated in favor of /api/browse/vendors/<vendor>/products.
+        """
+        return (
+            list(vulnerabilitylookup.get_vendor_products(vendor)),
+            200,
+            _deprecation_headers(f"/api/browse/vendors/{vendor}/products"),
+        )
 
 
 last_change_parser = reqparse.RequestParser()

--- a/website/web/api/v1/vulnerability.py
+++ b/website/web/api/v1/vulnerability.py
@@ -30,6 +30,7 @@ from website.web.meili import (
 )
 from website.web.permissions import admin_permission, reporter_permission
 
+from .browse import _deprecation_headers
 from .decorator_helpers import typed
 from .rate_limit import api_read_rate_limit
 
@@ -846,15 +847,19 @@ class VendorProductVulnerabilities(Resource):  # type: ignore[misc]
 
 
 @vulnerability_ns.route("/browse/")
-@vulnerability_ns.doc(description="Get the known vendors.")
+@vulnerability_ns.doc(
+    description="Deprecated: use GET /api/browse/vendors instead. "
+    "Get the known vendors.",
+    deprecated=True,
+)
 class Vendors(Resource):  # type: ignore[misc]
-    def get(self) -> list[str]:
-        """Get the known vendors."""
+    def get(self) -> tuple[list[str], int, dict[str, str]]:
+        """Get the known vendors. Deprecated in favor of /api/browse/vendors."""
         vendor = request.args.get("vendor", "").lower()
         vendors = list(vulnerabilitylookup.get_vendors())
         if vendor and len(vendor) >= 3:
             vendors = [elem for elem in vendors if vendor in elem]
-        return vendors
+        return vendors, 200, _deprecation_headers("/api/browse/vendors")
 
 
 @vulnerability_ns.route("/browse/assigners")

--- a/website/web/templates/main.html
+++ b/website/web/templates/main.html
@@ -171,7 +171,10 @@
                   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownKev" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                     KEV Catalogs
                   </a>
+
                   <ul class="dropdown-menu" aria-labelledby="navbarDropdownKev">
+                    <a class="dropdown-item" href="{{url_for('kev_catalogs_bp.list_kev_catalogs')}}">All catalogs</a>
+                    <div class="dropdown-divider"></div>
                     {% for catalog in kev_catalogs_menu %}
                       {% if catalog.is_local %}
                         <a class="dropdown-item" href="{{url_for('kev_catalog_bp.list_kev_catalog')}}">{{ catalog.short_name }}</a>


### PR DESCRIPTION
## Summary

Adds two new browse endpoints that expose, for each vendor and product, the date of its most recent vulnerability change — so API clients can poll only what actually changed instead of fanning out over every product.

Implements option 2 (a new dedicated endpoint) as agreed in the issue discussion, and signposts the long-standing legacy browse endpoints as deprecated without changing their behavior.

- `GET /api/browse/vendors`
- `GET /api/browse/vendors/<vendor>/products`

Both return the standard `{"metadata": {...}, "data": [...]}` shape with `{name, last_change}` objects, sorted by most recent change first. Entries whose last change date is not yet known come last with `last_change: null`.

Parameters: `q` (case-insensitive substring filter), `since` (ISO 8601 datetime or Unix timestamp; entries with unknown last-change dates are excluded), `page` / `per_page` (default 100, capped at 1000).

Example polling workflow, reduced to one call per vendor:

```
GET /api/browse/vendors/<vendor>/products?since=<last poll date>
```

## Implementation

- New `record_vendor_product_change()` helper (`vulnerabilitylookup/helpers.py`) maintains two zsets — `vendors:updated` and `{vendor}:products:updated` — using `ZADD GT`, so reimports and out-of-order imports never push a date backwards.
- Wired into every feeder that populates the vendor/product index: cvelistv5, nvd, fkie_nvd, certfr, jvndb, variot, osv_parser, gcve_vl, moksha.
- The reindex tool (`bin/index_vulnerabilities.py`) backfills the new zsets so existing instances get timestamps without waiting for new imports; `--purge` wipes them before rebuild and the key-contract docstring documents them.

## Legacy endpoint deprecation

Following the transition discussion in the issue, the legacy plain-list browse endpoints (`/api/browse/`, `/api/browse/<vendor>`, `/api/vulnerability/browse/`) keep working unchanged but now advertise their deprecation:

- `Deprecation: true`
- `Sunset: Mon, 14 Dec 2026 00:00:00 GMT` — a clearly-commented constant (`LEGACY_BROWSE_SUNSET`, ~6 months) to be re-anchored to the actual release date.
- `Link: <successor endpoint>; rel="successor-version", <issue #255>; rel="deprecation"` (the product endpoint's successor link is built per-request for the queried vendor).
- Marked `deprecated=True` in the OpenAPI docs (struck-through in Swagger UI).

Response bodies are unchanged (still bare arrays of names); the new metadata-aware endpoints carry no deprecation headers. The user-controlled vendor segment is percent-encoded (`quote(vendor, safe="")`) before being placed in the `Link` header, to prevent header injection.

**Not** included on purpose: actually redirecting the legacy queries to the new endpoint once the sunset passes — that is the breaking step and the date isn't firm yet, so it is left as a deliberate follow-up.

## Validation

- `mypy` and `ruff` pass on all touched files.
- Smoke-tested against a local instance: sorting, `since` filtering, pagination, `400` on invalid `since`; legacy endpoints still return plain string arrays and now carry the deprecation headers while the new endpoints do not; injection characters in the vendor segment are percent-encoded in the `Link` header.

## Follow-up

CPE alias search via https://cpe.gcve.eu/ (suggested in the issue) is intentionally left as a follow-up enhancement to these endpoints, which is why this PR references rather than closes the issue.

References #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
