### PR TITLE
Modernize global theme and chrome

### DIFF
--- a/website/web/static/css/theme.css
+++ b/website/web/static/css/theme.css
@@ -193,15 +193,10 @@ h1, .h1 { letter-spacing: -0.02em; }
   color: var(--bs-secondary-color);
 }
 
-/* Monospace identity for vulnerability identifiers, CVSS vectors, CPEs —
-   data that is code-like by nature. */
-.vl-id,
+/* Monospace identity for code-like data. The vulnerability detail page
+   applies the same treatment to its identifiers via a page-local rule. */
 code, kbd, samp, pre {
   font-family: var(--vl-font-mono);
-}
-.vl-id {
-  font-size: 0.95em;
-  letter-spacing: -0.01em;
 }
 
 /* Tabular figures for counters and stats so columns of numbers align. */

--- a/website/web/static/css/theme.css
+++ b/website/web/static/css/theme.css
@@ -1,173 +1,435 @@
+/* =========================================================================
+   Vulnerability-Lookup — "Analyst console" theme
+   -------------------------------------------------------------------------
+   A token-driven layer on top of Bootstrap 5.3. Wherever possible we steer
+   Bootstrap through its own --bs-* custom properties (scoped per
+   data-bs-theme) so components stay consistent instead of being overridden
+   one selector at a time. Brand colours are preserved:
+       slate  #446d80  → chrome, primary actions
+       azure  #006FBA  → links, accents, focus
+   The signature element is the "signal line": a thin slate→azure seam pinned
+   to the top of the page and echoed on nav hover and key card accents.
+   ========================================================================= */
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+:root {
+  /* Brand */
+  --vl-slate:        #446d80;
+  --vl-slate-600:    #3b5f70;
+  --vl-slate-700:    #2f4d5b;
+  --vl-azure:        #006FBA;
+  --vl-azure-600:    #0a5e9c;
+  --vl-azure-700:    #0b4f81;
+
+  /* RGB helpers for translucent fills */
+  --vl-slate-rgb:    68, 109, 128;
+  --vl-azure-rgb:    0, 111, 186;
+
+  /* Elevation — soft, layered, never heavy */
+  --vl-shadow-sm: 0 1px 2px rgba(20, 34, 43, 0.06), 0 1px 3px rgba(20, 34, 43, 0.05);
+  --vl-shadow:    0 2px 6px rgba(20, 34, 43, 0.07), 0 6px 18px rgba(20, 34, 43, 0.07);
+  --vl-shadow-lg: 0 8px 24px rgba(20, 34, 43, 0.12), 0 2px 8px rgba(20, 34, 43, 0.08);
+
+  /* Type */
+  --vl-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --vl-font-mono: ui-monospace, "SFMono-Regular", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+
+  /* Frosted topbar fill (light) */
+  --vl-topbar-bg: rgba(255, 255, 255, 0.82);
+}
+
+/* Light theme — also the document default */
+:root,
+[data-bs-theme="light"] {
+  color-scheme: light;
+
+  --bs-primary:            #446d80;
+  --bs-primary-rgb:        68, 109, 128;
+  --bs-link-color:         #006FBA;
+  --bs-link-color-rgb:     0, 111, 186;
+  --bs-link-hover-color:   #0a5e9c;
+  --bs-link-hover-color-rgb: 10, 94, 156;
+
+  --bs-body-bg:            #f5f7f9;
+  --bs-body-color:         #1d2b33;
+  --bs-secondary-color:    rgba(29, 43, 51, 0.62);
+  --bs-emphasis-color:     #14222b;
+
+  --bs-secondary-bg:       #eef1f4;
+  --bs-tertiary-bg:        #f0f3f5;
+  --bs-secondary-bg-rgb:   238, 241, 244;
+  --bs-tertiary-bg-rgb:    240, 243, 245;
+
+  --bs-border-color:             #e0e6ea;
+  --bs-border-color-translucent: rgba(20, 34, 43, 0.10);
+
+  --bs-card-bg:            #ffffff;
+  --bs-card-cap-bg:        transparent;
+
+  /* Radii — slightly softer than Bootstrap defaults */
+  --bs-border-radius:    0.6rem;
+  --bs-border-radius-sm: 0.4rem;
+  --bs-border-radius-lg: 0.85rem;
+  --bs-border-radius-xl: 1.1rem;
+
+  --vl-topbar-bg:  rgba(248, 250, 251, 0.85);
+  --vl-surface-2:  #ffffff;
+}
+
+/* Dark theme — deep slate-ink tinted toward the brand */
+[data-bs-theme="dark"] {
+  color-scheme: dark;
+
+  --bs-primary:            #6f9bb0;
+  --bs-primary-rgb:        111, 155, 176;
+  --bs-link-color:         #6fb6ec;
+  --bs-link-color-rgb:     111, 182, 236;
+  --bs-link-hover-color:   #99ccf3;
+  --bs-link-hover-color-rgb: 153, 204, 243;
+
+  --bs-body-bg:            #0e1519;
+  --bs-body-color:         #d7e0e6;
+  --bs-secondary-color:    rgba(215, 224, 230, 0.62);
+  --bs-emphasis-color:     #f3f7f9;
+
+  --bs-secondary-bg:       #16212a;
+  --bs-tertiary-bg:        #1a2730;
+  --bs-secondary-bg-rgb:   22, 33, 42;
+  --bs-tertiary-bg-rgb:    26, 39, 48;
+
+  --bs-border-color:             #273844;
+  --bs-border-color-translucent: rgba(255, 255, 255, 0.10);
+
+  --bs-card-bg:            #16212a;
+  --bs-card-cap-bg:        transparent;
+
+  --vl-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --vl-shadow:    0 2px 8px rgba(0, 0, 0, 0.45);
+  --vl-shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.55);
+
+  --vl-topbar-bg:  rgba(15, 23, 29, 0.78);
+  --vl-surface-2:  #1c2a34;
+}
+
+/* -------------------------------------------------------------------------
+   2. Base / layout
+   ------------------------------------------------------------------------- */
 html {
-    position: relative;
-    min-height: 100%;
+  min-height: 100%;
 }
 
 body {
-  /* Margin bottom by footer height + 5px */
-  margin-bottom: 65px;
-  padding-top: 0px;
+  font-family: var(--vl-font-sans);
+  /* Flexbox sticky footer: header / main(grow) / footer stack the page. */
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-.content-wrapper {
-  margin-top: 70px; /* Assuming the navbar is 70px tall */
+main {
+  flex: 1 0 auto;
+  padding-block: 0.5rem 2.5rem;
 }
 
-/* Wider-than-default content container for the main area.
-   Navbar and footer use container-fluid (full width); content stays
-   bounded for readability but uses more horizontal space than .container. */
+/* Wider-than-default content container for the main area. Navbar and footer
+   span full width; content stays bounded for readability. */
 .container-wide {
   width: 100%;
   max-width: 1600px;
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: var(--bs-gutter-x, 1.5rem);
-  padding-left: var(--bs-gutter-x, 1.5rem);
+  margin-inline: auto;
+  padding-inline: var(--bs-gutter-x, 1.5rem);
 }
-
 @media (max-width: 1199.98px) {
-  .container-wide {
-    max-width: 100%;
-  }
+  .container-wide { max-width: 100%; }
 }
 
-body[data-theme="light"] {
-  background-color: rgb(246, 248, 250);
+/* Legacy spacer kept for any page still referencing it. */
+.content-wrapper { margin-top: 70px; }
+
+::selection {
+  background: rgba(var(--vl-azure-rgb), 0.22);
 }
 
-img {
-  padding: 5px;
+/* Slim, themed scrollbars (progressive enhancement). */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--bs-border-color) transparent;
+}
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-thumb {
+  background: var(--bs-border-color);
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+*::-webkit-scrollbar-thumb:hover { background: rgba(var(--vl-slate-rgb), 0.55); }
+
+/* Keep user-inserted markdown images within their container. */
+.markdown-description img { max-width: 100%; height: auto; }
+
+/* -------------------------------------------------------------------------
+   3. Typography
+   ------------------------------------------------------------------------- */
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  font-weight: 650;
+  letter-spacing: -0.012em;
+  color: var(--bs-emphasis-color);
+}
+h1, .h1 { letter-spacing: -0.02em; }
+
+/* Eyebrow: a small, lettered label used to head sections or group menus.
+   Structural — it names a region, it doesn't decorate one. */
+.vl-eyebrow {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
 }
 
-/* Keep user-inserted markdown images (comments, bundles, disclosures, …)
-   within their container instead of overflowing the card. */
-.markdown-description img {
-  max-width: 100%;
-  height: auto;
+/* Monospace identity for vulnerability identifiers, CVSS vectors, CPEs —
+   data that is code-like by nature. */
+.vl-id,
+code, kbd, samp, pre {
+  font-family: var(--vl-font-mono);
+}
+.vl-id {
+  font-size: 0.95em;
+  letter-spacing: -0.01em;
 }
 
-.fading-line {
-  display: block;
-  border: none;
-  height: 1px;
-  padding: 0;
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(68, 109, 128, 0.75), rgba(0, 0, 0, 0));
-  background-repeat: no-repeat;
-  background-size: 100% 1px;
-  margin: 0 0 1rem 0;
-}
+/* Tabular figures for counters and stats so columns of numbers align. */
+.vl-tnum,
+.stat-value { font-variant-numeric: tabular-nums; }
 
-.logo {
-  max-width: 300px;
-}
-
-.choices__list,
-.choices__input {
-  color: black;
-}
-
-.input-inline {
-  min-width: 0;
-  width: 200px;
-  display: block;
-}
-
-
-/* Scroll to top button */
-#scrollToTopBtn {
-  width: 60px;
-  height: 60px;
-  bottom: 30px;
-  right: 30px;
+/* -------------------------------------------------------------------------
+   4. Signature: the signal line + sticky frosted topbar
+   ------------------------------------------------------------------------- */
+.vl-topbar {
+  position: sticky;
+  top: 0;
   z-index: 1030;
-
-  background-color: white;
-  color: #446d80;
-  border: 2px solid #d0d9df;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
-
-  opacity: 0;
-  transform: translateY(6px);
-  transition: opacity .25s ease, transform .25s ease, box-shadow .15s ease;
+  background: var(--vl-topbar-bg);
+  backdrop-filter: saturate(160%) blur(12px);
+  -webkit-backdrop-filter: saturate(160%) blur(12px);
+  border-bottom: 1px solid var(--bs-border-color-translucent);
+  transition: box-shadow 0.2s ease;
 }
+.vl-topbar.is-scrolled { box-shadow: var(--vl-shadow); }
 
-#scrollToTopBtn.show {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-#scrollToTopBtn:hover {
-  transform: translateY(-2px) scale(1.08);
-  box-shadow: 0 4px 10px rgba(0,0,0,0.25);
-}
-
-
-/* Sticky footer */
-.footer {
+/* The seam: a living slate→azure gradient pinned to the very top edge. */
+.vl-topbar::before {
+  content: "";
   position: absolute;
-  bottom: 0;
-  width: 100%;
-  /* Set the fixed height of the footer here */
-  height: 60px;
-  line-height: 60px; /* Vertically center the text there */
-  /* background-color: #343a40; */
-  background-color: #446d80 !important;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg,
+    var(--vl-slate) 0%, var(--vl-azure) 35%, var(--vl-slate) 70%, var(--vl-azure) 100%);
+  background-size: 220% 100%;
+  animation: vl-signal-shift 9s linear infinite;
 }
-.footer a {
-  color: rgb(255, 255, 255);
-  /* text-decoration: none; */
+@keyframes vl-signal-shift {
+  to { background-position: 220% 0; }
 }
 
-.truncate-cell {
-    max-width: 250px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+/* The same seam, used as a left accent on emphasised cards. */
+.vl-card-accent { position: relative; }
+.vl-card-accent::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  border-radius: var(--bs-border-radius) 0 0 var(--bs-border-radius);
+  background: linear-gradient(180deg, var(--vl-azure), var(--vl-slate));
 }
 
-.truncate-cell-sighting-table {
-    max-width: 200px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+/* -------------------------------------------------------------------------
+   5. Navbar
+   ------------------------------------------------------------------------- */
+.navbar { padding-block: 0.5rem; }
+
+.navbar-brand img#vulnerability-lookup-logo {
+  padding: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+.navbar-brand:hover img#vulnerability-lookup-logo { transform: translateY(-1px); }
+
+.navbar-nav .nav-link {
+  position: relative;
+  font-weight: 500;
+  color: var(--bs-body-color);
+  padding-inline: 0.85rem;
+  transition: color 0.15s ease;
+}
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus-visible,
+.navbar-nav .nav-link.active,
+.navbar-nav .show > .nav-link {
+  color: var(--vl-azure);
+}
+[data-bs-theme="dark"] .navbar-nav .nav-link:hover,
+[data-bs-theme="dark"] .navbar-nav .nav-link:focus-visible,
+[data-bs-theme="dark"] .navbar-nav .nav-link.active,
+[data-bs-theme="dark"] .navbar-nav .show > .nav-link {
+  color: var(--bs-link-color);
 }
 
-/* Button colors */
+/* Hover indicator — a short echo of the signal line under the active item. */
+.navbar-nav .nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0.85rem;
+  right: 0.85rem;
+  bottom: 0.15rem;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--vl-slate), var(--vl-azure));
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 0.2s ease;
+}
+.navbar-nav .nav-link:hover::after,
+.navbar-nav .nav-link.active::after,
+.navbar-nav .show > .nav-link::after { transform: scaleX(1); }
+/* Don't underline the icon-only search / theme toggles. */
+.navbar-nav .nav-link.vl-icon-link::after { content: none; }
+
+/* -------------------------------------------------------------------------
+   6. Dropdowns
+   ------------------------------------------------------------------------- */
+.dropdown-menu {
+  --bs-dropdown-border-color: var(--bs-border-color-translucent);
+  --bs-dropdown-border-radius: var(--bs-border-radius-lg);
+  --bs-dropdown-link-hover-bg: rgba(var(--vl-azure-rgb), 0.10);
+  --bs-dropdown-link-active-bg: var(--vl-slate);
+  padding: 0.4rem;
+  box-shadow: var(--vl-shadow-lg);
+}
+.dropdown-item {
+  border-radius: var(--bs-border-radius-sm);
+  padding-block: 0.4rem;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+.dropdown-item:hover { color: var(--vl-azure); }
+[data-bs-theme="dark"] .dropdown-item:hover { color: var(--bs-link-color); }
+
+/* Menu section labels (rendered as .dropdown-item.text-muted) read as eyebrows. */
+.dropdown-menu .dropdown-item.text-muted {
+  pointer-events: none;
+  padding-top: 0.55rem;
+}
+.dropdown-menu .dropdown-item.text-muted p {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+/* -------------------------------------------------------------------------
+   7. Buttons — brand variants with explicit interaction states
+   ------------------------------------------------------------------------- */
+.btn {
+  --bs-btn-font-weight: 550;
+  --bs-btn-border-radius: var(--bs-border-radius);
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+              color 0.15s ease, box-shadow 0.15s ease, transform 0.05s ease;
+}
+.btn:active { transform: translateY(1px); }
+
 .btn-primary {
-  background-color: #446d80;
-  border-color: #446d80;
-  color: white;
-}
-.btn-outline-primary {
-  border-color: #006FBA;
-  color: #006FBA;
+  --bs-btn-bg: var(--vl-slate);
+  --bs-btn-border-color: var(--vl-slate);
+  --bs-btn-hover-bg: var(--vl-slate-600);
+  --bs-btn-hover-border-color: var(--vl-slate-600);
+  --bs-btn-active-bg: var(--vl-slate-700);
+  --bs-btn-active-border-color: var(--vl-slate-700);
+  --bs-btn-disabled-bg: var(--vl-slate);
+  --bs-btn-disabled-border-color: var(--vl-slate);
+  --bs-btn-color: #fff;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
 }
 .btn-secondary {
-  background-color: #006FBA;
-  color: white;
+  --bs-btn-bg: var(--vl-azure);
+  --bs-btn-border-color: var(--vl-azure);
+  --bs-btn-hover-bg: var(--vl-azure-600);
+  --bs-btn-hover-border-color: var(--vl-azure-600);
+  --bs-btn-active-bg: var(--vl-azure-700);
+  --bs-btn-active-border-color: var(--vl-azure-700);
+  --bs-btn-color: #fff;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
 }
 .btn-default {
-  background-color: #006FBA;
-  color: white;
+  --bs-btn-bg: var(--vl-azure);
+  --bs-btn-border-color: var(--vl-azure);
+  --bs-btn-color: #fff;
+}
+.btn-outline-primary {
+  --bs-btn-color: var(--vl-azure);
+  --bs-btn-border-color: var(--vl-azure);
+  --bs-btn-hover-bg: var(--vl-azure);
+  --bs-btn-hover-border-color: var(--vl-azure);
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-bg: var(--vl-azure-600);
+  --bs-btn-active-border-color: var(--vl-azure-600);
 }
 
-.alert-primary {
-  background-color: #446d80;
-  color: white;
+/* -------------------------------------------------------------------------
+   8. Focus — a single, visible, on-brand focus ring everywhere
+   ------------------------------------------------------------------------- */
+:focus-visible {
+  outline: 2px solid var(--vl-azure);
+  outline-offset: 2px;
+}
+.btn:focus-visible,
+.form-control:focus,
+.form-select:focus,
+.form-check-input:focus {
+  box-shadow: 0 0 0 0.2rem rgba(var(--vl-azure-rgb), 0.30);
+  border-color: var(--vl-azure);
+}
+.form-check-input:checked {
+  background-color: var(--vl-azure);
+  border-color: var(--vl-azure);
 }
 
-.bg-primary {
-  background-color: #446d80 !important;
-  color: white;
+/* -------------------------------------------------------------------------
+   9. Cards
+   ------------------------------------------------------------------------- */
+.card {
+  --bs-card-border-color: var(--bs-border-color-translucent);
+  --bs-card-border-radius: var(--bs-border-radius-lg);
+  --bs-card-inner-border-radius: calc(var(--bs-border-radius-lg) - 1px);
+  box-shadow: var(--vl-shadow-sm);
 }
 
+/* Rounded card with a soft lift on hover. */
+.vl-card {
+  --bs-card-border-radius: 0.85rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.vl-card:hover { box-shadow: var(--vl-shadow-lg) !important; }
 
-/* =========================================================
-   Harmonized card design language
-   Shared by the About page, the home page and the
-   vulnerability source-view macros so new pages can opt in
-   to the same look with a couple of classes.
-   ========================================================= */
+/* Standalone feature tile: visible border and a stronger lift. */
+.vl-card-feature {
+  height: 100%;
+  border: 1px solid var(--bs-border-color);
+}
+.vl-card-feature:hover { transform: translateY(-4px); }
+
+/* Header that drops the default fill so the icon badge leads. */
+.vl-card-header {
+  background: transparent;
+  border-bottom: 1px solid var(--bs-border-color-translucent);
+}
 
 /* Brand-tinted, rounded icon badge used to lead card headers. */
 .vl-icon-badge {
@@ -177,18 +439,19 @@ img {
   width: 42px;
   height: 42px;
   border-radius: 12px;
-  background: rgba(0, 111, 186, 0.12);
-  color: #006FBA;
+  background: rgba(var(--vl-azure-rgb), 0.12);
+  color: var(--vl-azure);
   font-size: 1.2rem;
   flex-shrink: 0;
   text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 a.vl-icon-badge:hover {
-  background: rgba(0, 111, 186, 0.2);
-  color: #006FBA;
+  background: rgba(var(--vl-azure-rgb), 0.2);
+  color: var(--vl-azure);
+  transform: translateY(-1px);
 }
-/* Compact variant for tighter headers (e.g. h6 titles). */
+[data-bs-theme="dark"] .vl-icon-badge { color: var(--bs-link-color); }
 .vl-icon-badge-sm {
   width: 36px;
   height: 36px;
@@ -196,27 +459,158 @@ a.vl-icon-badge:hover {
   font-size: 1rem;
 }
 
-/* Rounded card with a soft shadow on hover. Uses Bootstrap's
-   card radius variable so headers/footers round to match. */
-.vl-card {
-  --bs-card-border-radius: 0.85rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.vl-card:hover {
-  box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.12) !important;
+/* -------------------------------------------------------------------------
+   10. Forms, tables, badges, misc components
+   ------------------------------------------------------------------------- */
+.form-control,
+.form-select {
+  border-color: var(--bs-border-color);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-/* Standalone feature tile: visible border and a stronger lift. */
-.vl-card-feature {
-  height: 100%;
+.logo { max-width: 300px; }
+
+.choices__list,
+.choices__input { color: var(--bs-body-color); }
+
+.input-inline {
+  min-width: 0;
+  width: 200px;
+  display: block;
+}
+
+.table {
+  --bs-table-border-color: var(--bs-border-color-translucent);
+}
+.table > thead th {
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}
+
+.badge { font-weight: 600; letter-spacing: 0.01em; }
+
+.truncate-cell {
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.truncate-cell-sighting-table {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Soft divider — kept for pages that use it inline. */
+.fading-line {
+  display: block;
+  border: none;
+  height: 1px;
+  padding: 0;
+  background-image: linear-gradient(to right,
+    rgba(var(--vl-slate-rgb), 0), rgba(var(--vl-slate-rgb), 0.55), rgba(var(--vl-slate-rgb), 0));
+  background-repeat: no-repeat;
+  background-size: 100% 1px;
+  margin: 0 0 1rem 0;
+}
+
+/* Brand-tinted utilities (kept for existing markup). */
+.alert-primary {
+  --bs-alert-bg: rgba(var(--vl-slate-rgb), 0.10);
+  --bs-alert-border-color: rgba(var(--vl-slate-rgb), 0.25);
+  --bs-alert-color: var(--vl-slate-700);
+}
+[data-bs-theme="dark"] .alert-primary { --bs-alert-color: #cfe0e8; }
+.bg-primary { background-color: var(--vl-slate) !important; color: #fff; }
+
+/* -------------------------------------------------------------------------
+   11. Scroll-to-top button
+   ------------------------------------------------------------------------- */
+#scrollToTopBtn {
+  width: 52px;
+  height: 52px;
+  bottom: 30px;
+  right: 30px;
+  z-index: 1030;
+  background-color: var(--vl-surface-2);
+  color: var(--vl-slate);
   border: 1px solid var(--bs-border-color);
+  box-shadow: var(--vl-shadow);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.25s ease, transform 0.25s ease, box-shadow 0.15s ease;
 }
-.vl-card-feature:hover {
-  transform: translateY(-4px);
+[data-bs-theme="dark"] #scrollToTopBtn { color: var(--bs-link-color); }
+#scrollToTopBtn.show { opacity: 1; transform: translateY(0); }
+#scrollToTopBtn:hover {
+  transform: translateY(-2px) scale(1.06);
+  box-shadow: var(--vl-shadow-lg);
 }
 
-/* Header that drops the default fill so the icon badge leads. */
-.vl-card-header {
-  background: transparent;
-  border-bottom: 1px solid var(--bs-border-color-translucent);
+/* -------------------------------------------------------------------------
+   12. Footer — anchored brand base in both themes
+   ------------------------------------------------------------------------- */
+.footer {
+  flex-shrink: 0;
+  position: relative;
+  background: linear-gradient(180deg, var(--vl-slate) 0%, var(--vl-slate-700) 100%) !important;
+  color: rgba(255, 255, 255, 0.85);
+  padding-block: 2rem;
+  margin-top: 2rem;
+}
+/* The signal line, mirrored along the footer's top edge. */
+.footer::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--vl-azure), var(--vl-slate), var(--vl-azure));
+  background-size: 220% 100%;
+  animation: vl-signal-shift 9s linear infinite;
+}
+.footer a {
+  color: #fff;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+.footer a:hover { opacity: 0.75; text-decoration: underline; }
+.footer .vl-footer-brand { max-height: 40px; }
+.footer .vl-footer-tagline {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+  max-width: 42ch;
+}
+.footer .vl-footer-heading {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 0.6rem;
+}
+.footer .vl-footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+/* -------------------------------------------------------------------------
+   13. Motion floor
+   ------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/website/web/static/css/theme.css
+++ b/website/web/static/css/theme.css
@@ -238,14 +238,18 @@ code, kbd, samp, pre {
   to { background-position: 220% 0; }
 }
 
-/* The same seam, used as a left accent on emphasised cards. */
-.vl-card-accent { position: relative; }
-.vl-card-accent::before {
+/* The same seam, used as a left accent on emphasised cards. The detail page's
+   primary record card opts in via the .vl-primary-view wrapper, so the accent
+   marks the focal card without repeating on every related/list card. */
+.vl-card-accent,
+.vl-primary-view > .card { position: relative; }
+.vl-card-accent::before,
+.vl-primary-view > .card::before {
   content: "";
   position: absolute;
   inset: 0 auto 0 0;
   width: 3px;
-  border-radius: var(--bs-border-radius) 0 0 var(--bs-border-radius);
+  border-radius: var(--bs-border-radius-lg) 0 0 var(--bs-border-radius-lg);
   background: linear-gradient(180deg, var(--vl-azure), var(--vl-slate));
 }
 

--- a/website/web/templates/admin/dashboard.html
+++ b/website/web/templates/admin/dashboard.html
@@ -7,11 +7,11 @@
 
 {% block title %}Dashboard{% endblock %}
 {% block content %}
-<h1 class="visually-hidden">Dashboard</h1>
+<div class="mb-4"><span class="vl-eyebrow">Admin</span><h1 class="h3 mb-0">Dashboard</h1></div>
 <div class="row">
   <!-- Storage Panel -->
   <div class="col-md-6">
-    <div class="card shadow-sm">
+    <div class="card vl-card shadow-sm">
       <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
         <h4 class="mb-0">{{ render_icon('hdd-stack', title='Storage') }} Storage</h4>
         <button class="btn btn-outline-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#collapseStorage" aria-expanded="false" aria-controls="collapseStorage">
@@ -34,7 +34,7 @@
           <div class="col">
             <div class="d-flex justify-content-between align-items-center p-3 border rounded shadow-sm">
               <span>{{ label }}</span>
-              <a href="{{ link }}" class="badge bg-primary fs-6 text-truncate" style="max-width:120px;" title="{{ value }}">{{ value }}</a>
+              <a href="{{ link }}" class="badge bg-primary fs-6 text-truncate vl-tnum" style="max-width:120px;" title="{{ value }}">{{ value }}</a>
             </div>
           </div>
           {% endfor %}
@@ -44,7 +44,7 @@
             <div class="d-flex justify-content-between align-items-center p-3 border rounded shadow-sm">
               <span>Vulnerability disclosures</span>
               <span>
-                <a href="{{ url_for('admin_vulnerability_disclosures_bp.list_vulnerability_disclosures') }}" class="badge bg-primary fs-6">{{ nb_disclosures }}</a>
+                <a href="{{ url_for('admin_vulnerability_disclosures_bp.list_vulnerability_disclosures') }}" class="badge bg-primary fs-6 vl-tnum">{{ nb_disclosures }}</a>
                 {% if new_disclosures >= 1 %}
                   <span class="badge bg-warning text-dark ms-1">new report{% if new_disclosures > 1 %}s{% endif %}!</span>
                 {% endif %}
@@ -55,7 +55,7 @@
           <div class="col">
             <div class="d-flex justify-content-between align-items-center p-3 border rounded shadow-sm">
               <span>CNA publications</span>
-              <a href="{{ url_for('cna_publication_bp.publications') }}" class="badge bg-primary fs-6">{{ nb_cna_publications }}</a>
+              <a href="{{ url_for('cna_publication_bp.publications') }}" class="badge bg-primary fs-6 vl-tnum">{{ nb_cna_publications }}</a>
             </div>
           </div>
           <div class="col">
@@ -85,7 +85,7 @@
           ] %}
 
   <div class="col-md-6">
-    <div class="card shadow-sm">
+    <div class="card vl-card shadow-sm">
       <div class="card-header bg-success text-white d-flex align-items-center">
         <h4 class="mb-0">{{ render_icon('speedometer2', title='Instance Status') }} Instance Status</h4>
       </div>
@@ -118,7 +118,7 @@
       </div>
     </div>
 
-        <div class="card shadow-sm mt-3">
+        <div class="card vl-card shadow-sm mt-3">
       <div class="card-header d-flex justify-content-between align-items-center bg-secondary text-white">
         <h4 class="mb-0">{{ render_icon('diagram-2', title='GCVE registry') }} GCVE registry</h4>
         <div class="btn-group">
@@ -135,7 +135,7 @@
           <div class="col">
             <div class="d-flex justify-content-between align-items-center p-3 border rounded shadow-sm">
               <span>{{ render_icon('list-check', title='Known GNAs') }} Known GNAs</span>
-              <span class="badge bg-primary fs-6">{{ GNAs | count }}</span>
+              <span class="badge bg-primary fs-6 vl-tnum">{{ GNAs | count }}</span>
             </div>
           </div>
           <div class="col">
@@ -172,7 +172,7 @@
 <div class="row mt-3">
   <!-- Maintenance Panel -->
   <div class="col">
-    <div class="card shadow-sm">
+    <div class="card vl-card shadow-sm">
       <div class="card-header bg-warning text-dark d-flex align-items-center">
         <h4 class="mb-0">{{ render_icon('tools', title='Maintenance') }} Maintenance</h4>
       </div>

--- a/website/web/templates/admin/edit_bundle.html
+++ b/website/web/templates/admin/edit_bundle.html
@@ -26,6 +26,7 @@
 </div>
 <div class="row">
   <div class="col">
+    <span class="vl-eyebrow">Admin</span>
     <h2>{{ action | safe }}</h2>
   </div>
   <div class="col text-end">

--- a/website/web/templates/admin/edit_kev.html
+++ b/website/web/templates/admin/edit_kev.html
@@ -6,6 +6,7 @@
 {% block content %}
 <div class="row mb-3">
   <div class="col">
+    <span class="vl-eyebrow">Admin</span>
     <h1>{{ action }}</h1>
     {% if kev_entry %}
       <p class="text-muted">Managing: <strong>{{ kev_entry.vuln_id.upper() }}</strong></p>

--- a/website/web/templates/admin/edit_organization.html
+++ b/website/web/templates/admin/edit_organization.html
@@ -7,6 +7,7 @@
 {% endblock %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 {{ render_form(form, extra_classes="form-control") }}
 <br />

--- a/website/web/templates/admin/edit_organization_cpe_vendor.html
+++ b/website/web/templates/admin/edit_organization_cpe_vendor.html
@@ -2,6 +2,7 @@
 {% from 'bootstrap5/form.html' import render_form %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 <h2 class="mt-4">Associated CPE vendor names</h2>
 <ul class="list-group">

--- a/website/web/templates/admin/edit_product.html
+++ b/website/web/templates/admin/edit_product.html
@@ -7,6 +7,7 @@
 {% endblock %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 {{ render_form(form, extra_classes="form-control") }}
 <br />

--- a/website/web/templates/admin/edit_product_cpe_product.html
+++ b/website/web/templates/admin/edit_product_cpe_product.html
@@ -2,6 +2,7 @@
 {% from 'bootstrap5/form.html' import render_form %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 <h2 class="mt-4">Associated CPE product names</h2>
 <ul class="list-group">

--- a/website/web/templates/admin/edit_remote_instance.html
+++ b/website/web/templates/admin/edit_remote_instance.html
@@ -2,9 +2,10 @@
 {% from 'bootstrap5/form.html' import render_form %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 {% if instance is defined and instance %}
-<div class="card mb-3">
+<div class="card vl-card mb-3">
   <div class="card-body">
     <strong>Last sync:</strong>
     {% if instance.last_sync %}

--- a/website/web/templates/admin/edit_sighting.html
+++ b/website/web/templates/admin/edit_sighting.html
@@ -4,6 +4,7 @@
 {% block title %}{{ action }}{% endblock %}
 
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 {{ render_form(form, extra_classes="form-control") }}
 <br />

--- a/website/web/templates/admin/edit_user.html
+++ b/website/web/templates/admin/edit_user.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-center mt-5">
-  <div class="card shadow-sm" style="width: 100%;">
+  <div class="card vl-card shadow-sm" style="width: 100%;">
     <div class="card-body">
       <h3 class="card-title mb-4 text-center">{{ action }}</h3>
       {{ render_form(form, extra_classes="form-control") }}

--- a/website/web/templates/admin/edit_vulnerability_disclosure.html
+++ b/website/web/templates/admin/edit_vulnerability_disclosure.html
@@ -9,6 +9,7 @@
 {% endblock %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>{{ action }}</h1>
 <form method="post" action="">
   {{ form.hidden_tag() }}

--- a/website/web/templates/admin/feeders.html
+++ b/website/web/templates/admin/feeders.html
@@ -5,6 +5,7 @@
 {% endblock %}
 {% block title %}Feeders Monitoring{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>Feeders Monitoring</h1>
 <div class="row">
   <div class="col">

--- a/website/web/templates/admin/processes.html
+++ b/website/web/templates/admin/processes.html
@@ -5,6 +5,7 @@
 {% endblock %}
 {% block title %}Process Monitoring{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h1>Process Monitoring</h1>
 <div class="row">
   <div class="col">

--- a/website/web/templates/admin/products.html
+++ b/website/web/templates/admin/products.html
@@ -3,6 +3,7 @@
 {% block content %}
 <div class="row">
   <div class="col-md-9">
+    <span class="vl-eyebrow">Admin</span>
     <h1>Products</h1>
   </div>
   <div class="col-md-3">

--- a/website/web/templates/admin/remote_instances.html
+++ b/website/web/templates/admin/remote_instances.html
@@ -89,7 +89,7 @@
 
 <div class="row mt-4">
   <div class="col">
-    <div class="card">
+    <div class="card vl-card">
       <div class="card-header">
         <h5 class="mb-0">Documentation</h5>
       </div>

--- a/website/web/templates/admin/view_comment.html
+++ b/website/web/templates/admin/view_comment.html
@@ -3,6 +3,7 @@
 {% block title %}Comment overview{% endblock %}
 
 {% block content %}
+<span class="vl-eyebrow">Admin</span>
 <h2>Comment overview</h2>
 <hr />
 <p><b>Vulnerability</b>: <a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=comment.vulnerability) }}">{{ comment.vulnerability }}</a></p>

--- a/website/web/templates/bundles/bundle.html
+++ b/website/web/templates/bundles/bundle.html
@@ -9,10 +9,11 @@
 {% block title %}Bundle - {{ bundle.name }}{% endblock %}
 {% block content %}
 
-<div class="card vl-card shadow-sm mb-4">
+<div class="card vl-card vl-card-accent shadow-sm mb-4">
   <div class="card-header vl-card-header d-flex align-items-center gap-3">
     <span class="vl-icon-badge">{{ render_icon('box-seam') }}</span>
     <div class="flex-grow-1">
+      <span class="vl-eyebrow">Bundle</span>
       <h4 class="card-title mb-0">
         <a href="{{ url_for('bundle_bp.get', bundle_uuid=bundle.uuid) }}">{{ bundle.name | safe }}</a>
       </h4>
@@ -143,7 +144,7 @@
   <div class="card-body">
     <div class="table-responsive">
       <table class="table align-middle">
-        <thead class="table-light">
+        <thead>
           <tr>
             <th scope="col">Author</th>
             <th scope="col">Vulnerability</th>

--- a/website/web/templates/bundles/bundles.html
+++ b/website/web/templates/bundles/bundles.html
@@ -7,7 +7,7 @@
 {% endblock %}
 {% block title %}Bundles{% endblock %}
 {% block content %}
-  <h1>Recent bundles</h1>
+  <div class="mb-3"><span class="vl-eyebrow">Community</span><h1 class="h3 mb-0">Recent bundles</h1></div>
   <div class="row align-items-center ">
     <div class="col d-flex flex-column flex-md-row align-items-start align-items-md-center">
       {% if current_user.is_authenticated and current_user.is_admin %}

--- a/website/web/templates/comments/comment.html
+++ b/website/web/templates/comments/comment.html
@@ -7,10 +7,11 @@
 {% block title %}Comment - {{ comment.title }}{% endblock %}
 {% block content %}
 
-<div class="card vl-card shadow-sm mb-4">
+<div class="card vl-card vl-card-accent shadow-sm mb-4">
   <div class="card-header vl-card-header d-flex align-items-center gap-3">
     <span class="vl-icon-badge">{{ render_icon('chat-square-text') }}</span>
     <div class="flex-grow-1">
+      <span class="vl-eyebrow">Comment</span>
       <h4 class="card-title mb-0">
         <a href="{{ url_for('comment_bp.get', comment_uuid=comment.uuid) }}">
           {{ comment.title | safe }}

--- a/website/web/templates/comments/comments.html
+++ b/website/web/templates/comments/comments.html
@@ -9,7 +9,7 @@
 {% endblock %}
 {% block title %}Comments{% endblock %}
 {% block content %}
-<h1>Recent comments</h1>
+<div class="mb-3"><span class="vl-eyebrow">Community</span><h1 class="h3 mb-0">Recent comments</h1></div>
 {% if not current_user.is_authenticated %}
 <div class="row mb-3">
   <div class="col">

--- a/website/web/templates/comments/edit_comment.html
+++ b/website/web/templates/comments/edit_comment.html
@@ -38,6 +38,7 @@
 
 <div class="row">
   <div class="col">
+    <span class="vl-eyebrow">Community</span>
     <h2>{{ action | safe }}</h2>
   </div>
   <div class="col text-end">

--- a/website/web/templates/cwes/cwe_detail.html
+++ b/website/web/templates/cwes/cwe_detail.html
@@ -2,8 +2,9 @@
 {% import 'vulnerability_templates.html' as vuln_templates with context %}
 {% block title %}CWE-{{ cwe["@ID"] }}{% endblock %}
 {% block content %}
-<h1>CWE-{{ cwe["@ID"] }}</h1>
-<h2>{{ cwe["@Name"] }}</h2>
+<span class="vl-eyebrow">Common Weakness Enumeration</span>
+<h1 class="mb-1">CWE-{{ cwe["@ID"] }}</h1>
+<h2 class="h4 text-body-secondary">{{ cwe["@Name"] }}</h2>
 
 {% if cwe["Description"] %}
   <div class="mb-4">
@@ -57,7 +58,7 @@
         {% set mitigations = mitigations_raw %}
     {% endif %}
     {% for mitigation in mitigations %}
-    <div class="card mb-4">
+    <div class="card vl-card mb-4">
         <div class="card-body">
         {% if mitigation.get("@Mitigation_ID") %}
           <h5 class="card-title">Mitigation ID: {{ mitigation["@Mitigation_ID"] }}</h5>
@@ -98,7 +99,7 @@
       {% set capec_id = raw_capec.get("@CAPEC_ID") or raw_capec.get("@ID") if raw_capec is mapping else None %}
       {% if capec_id %}
         {% set capec = capec_id | get_capec %}
-        <div class="card mb-3">
+        <div class="card vl-card mb-3">
           <div class="card-body">
             <h5 class="card-title">
               CAPEC-{{ capec["@CAPEC_ID"] }}: {{ capec["@Name"] }}
@@ -111,7 +112,7 @@
           </div>
         </div>
       {% else %}
-        <div class="card mb-3">
+        <div class="card vl-card mb-3">
           <div class="card-body">
             <p><em>Invalid or missing CAPEC id.</em></p>
           </div>

--- a/website/web/templates/kev_catalog.html
+++ b/website/web/templates/kev_catalog.html
@@ -1,8 +1,9 @@
 {% extends "main.html" %}
 {% block title %}Known Exploited Vulnerabilities Catalog{% endblock %}
 {% block content %}
-<div class="row">
+<div class="row mb-3">
   <div class="col-md-9">
+    <span class="vl-eyebrow">KEV</span>
     <h1>Known Exploited Vulnerabilities Catalog</h1>
     <p class="text-muted">
       {% if is_local_catalog %}
@@ -39,7 +40,7 @@
   <div class="card-header vl-card-header d-flex align-items-center gap-3">
     <span class="vl-icon-badge">{{ render_icon('fire') }}</span>
     <h5 class="mb-0">KEV Entries</h5>
-    <span class="badge bg-info">{{ pagination.total }}</span>
+    <span class="badge bg-info vl-tnum">{{ pagination.total }}</span>
     <div class="d-flex gap-2 fs-5 ms-auto">
       <a class="icon-link" href="{{ url_for('kev_catalog_bp.feed_kev_catalog', feed_format='atom', catalog_uuid=catalog_uuid if not is_local_catalog else none) }}" type="application/atom+xml" title="Atom feed">
         {{ render_icon('rss') }}
@@ -135,7 +136,7 @@
           <td>
             {% set evidence_count = kev.evidence.count() %}
             {% if evidence_count > 0 %}
-              <span class="badge bg-info">{{ evidence_count }}</span>
+              <span class="badge bg-info vl-tnum">{{ evidence_count }}</span>
               {% if evidence_count == 1 %}
                 <small class="text-muted">source</small>
               {% else %}

--- a/website/web/templates/kev_catalogs_list.html
+++ b/website/web/templates/kev_catalogs_list.html
@@ -5,6 +5,7 @@
   <div class="col">
     <div class="d-flex align-items-start gap-3">
       <div class="flex-grow-1">
+        <span class="vl-eyebrow">KEV</span>
         <h1>Known Exploited Vulnerability Catalogs</h1>
         <p class="text-muted">
           Catalogs of Known Exploited Vulnerabilities (KEV) explorable via this Vulnerability-Lookup instance.
@@ -40,7 +41,7 @@
               {% endif %}
             </h5>
             <small class="text-body-secondary">
-              {{ catalog.entry_count }} {% if catalog.entry_count == 1 %}entry{% else %}entries{% endif %}
+              <span class="vl-tnum">{{ catalog.entry_count }}</span> {% if catalog.entry_count == 1 %}entry{% else %}entries{% endif %}
             </small>
           </div>
         </div>
@@ -83,7 +84,7 @@
         showing in which KEV catalogs each vulnerability appears.
       </small>
     </div>
-    <span class="badge bg-info">{{ matrix_pagination.total }}</span>
+    <span class="badge bg-info vl-tnum">{{ matrix_pagination.total }}</span>
   </div>
   <div class="card-body p-0">
     <div class="table-responsive">

--- a/website/web/templates/kev_detail.html
+++ b/website/web/templates/kev_detail.html
@@ -5,6 +5,7 @@
 {% block content %}
 <div class="row mb-3">
   <div class="col">
+    <span class="vl-eyebrow">KEV Entry</span>
     <h1>{{ kev_entry.vuln_id.upper() }}</h1>
     <p class="text-muted">
       Known Exploited Vulnerability Entry
@@ -214,7 +215,7 @@
   <div class="card-header vl-card-header d-flex align-items-center gap-3">
     <span class="vl-icon-badge">{{ render_icon('clipboard-data') }}</span>
     <h5 class="mb-0 flex-grow-1">Evidence</h5>
-    <span class="badge bg-info">{{ evidence_list|length }}</span>
+    <span class="badge bg-info vl-tnum">{{ evidence_list|length }}</span>
   </div>
   {% if evidence_list %}
   <div class="card-body p-0">

--- a/website/web/templates/main.html
+++ b/website/web/templates/main.html
@@ -144,7 +144,8 @@
   </head>
   <body>
     <header>
-      <div class="container-fluid px-4">
+      <div class="vl-topbar" id="vlTopbar">
+        <div class="container-fluid px-4">
         {% block navigation %}
         <nav class="navbar navbar-expand-lg">
           <div class="container-fluid px-0">
@@ -304,7 +305,7 @@
                 {% endif %}
 
                 <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownSearch" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ render_icon('search') }}</a>
+                  <a class="nav-link dropdown-toggle vl-icon-link" href="#" id="navbarDropdownSearch" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ render_icon('search') }}</a>
                   <div class="dropdown-menu dropdown-menu-end p-3 shadow" aria-labelledby="navbarDropdownSearch" style="width: 340px;">
                     <form class="d-flex" role="form" method="GET" action="/search">
                       <label for="freetext_search" class="visually-hidden">Search term</label>
@@ -322,7 +323,7 @@
                 </li>
 
                 <li class="nav-item">
-                  <a class="nav-link" id="btnThemeSwitch" href="#" title="Switch to dark theme">
+                  <a class="nav-link vl-icon-link" id="btnThemeSwitch" href="#" title="Switch to dark theme">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-moon-stars-fill" viewBox="0 0 16 16">
                       <path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/>
                       <path d="M10.794 3.148a.217.217 0 0 1 .412 0l.387 1.162c.173.518.579.924 1.097 1.097l1.162.387a.217.217 0 0 1 0 .412l-1.162.387a1.73 1.73 0 0 0-1.097 1.097l-.387 1.162a.217.217 0 0 1-.412 0l-.387-1.162A1.73 1.73 0 0 0 9.31 6.593l-1.162-.387a.217.217 0 0 1 0-.412l1.162-.387a1.73 1.73 0 0 0 1.097-1.097zM13.863.099a.145.145 0 0 1 .274 0l.258.774c.115.346.386.617.732.732l.774.258a.145.145 0 0 1 0 .274l-.774.258a1.16 1.16 0 0 0-.732.732l-.258.774a.145.145 0 0 1-.274 0l-.258-.774a1.16 1.16 0 0 0-.732-.732l-.774-.258a.145.145 0 0 1 0-.274l.774-.258c.346-.115.617-.386.732-.732z"/>
@@ -333,8 +334,10 @@
             </div>
           </div>
         </nav>
-        <hr class="fading-line">
         {% endblock%}
+        </div>
+      </div>
+      <div class="container-fluid px-4">
         {{ render_messages(container=True, dismissible=True) }}
 
         {% block reusablemodals %}
@@ -385,27 +388,33 @@
     <!-- Scroll to Top Button -->
     <button id="scrollToTopBtn" class="btn btn-primary rounded-circle shadow position-fixed d-none" title="Scroll to top.">{{ render_icon('chevron-up') }}</button>
 
-    <footer class="footer bg-light">
+    <footer class="footer">
       <div class="container-fluid px-4">
-        <div class="row">
-          <div class="col d-none d-md-block">
-            <div class="d-flex justify-content-start">
-              <span class="text-muted"><a href="{{ config.ADMIN_WEBSITE }}" rel="noreferrer" target="_blank">{{ config.ADMIN_NAME }}</a></span>
-            </div>
+        <div class="row gy-4">
+          <div class="col-lg-5">
+            <img class="vl-footer-brand mb-2" src="{{ url_for('static', filename='img/VL-hori-white-coul.png') }}" alt="Vulnerability-Lookup">
+            <p class="vl-footer-tagline mb-2">Fast vulnerability lookup and correlation across dozens of sources — and a collaborative space for coordinated disclosure.</p>
+            <span class="vl-footer-tagline">Operated by <a href="{{ config.ADMIN_WEBSITE }}" rel="noreferrer" target="_blank">{{ config.ADMIN_NAME }}</a></span>
           </div>
-          <div class="col">
-            <div class="d-flex justify-content-end">
+          <div class="col-6 col-lg-3 offset-lg-1">
+            <div class="vl-footer-heading">Resources</div>
+            <ul class="vl-footer-links">
+              <li><a href="{{ url_for('documentation_bp.serve_index') }}">Documentation</a></li>
+              <li><a href="{{ url_for('apiv1.doc') }}">API</a></li>
+              {% if config.user_accounts %}
+              <li><a href="{{ url_for('users_bp.list_users') }}">Contributors</a></li>
+              {% endif %}
               {% if config.BULK_DUMPS_URL %}
-              <a class="text-end d-none d-md-block" href="{{ config.BULK_DUMPS_URL }}" rel="noreferrer" target="_blank">Dumps</a>&nbsp;&nbsp;
+              <li><a href="{{ config.BULK_DUMPS_URL }}" rel="noreferrer" target="_blank">Dumps</a></li>
               {% endif %}
-              {% if config.user_accounts  %}
-              <a class="text-end" href="{{ url_for('users_bp.list_users') }}">Contributors</a>&nbsp;&nbsp;
-              {% endif %}
-              <a class="text-end" href="{{ url_for('documentation_bp.serve_index') }}">Documentation</a>&nbsp;&nbsp;
-              <a class="text-end" href="{{ url_for('apiv1.doc') }}">API</a>&nbsp;&nbsp;
-              <a class="text-end" href="{{ url_for('home_bp.about') }}">About</a>&nbsp;&nbsp;
-              <a class="text-end" href="https://github.com/vulnerability-lookup/vulnerability-lookup" title="Source code of Vulnerability-Lookup" target="_blank">{{ render_icon('github') }}</a>
-            </div>
+            </ul>
+          </div>
+          <div class="col-6 col-lg-3">
+            <div class="vl-footer-heading">Project</div>
+            <ul class="vl-footer-links">
+              <li><a href="{{ url_for('home_bp.about') }}">About</a></li>
+              <li><a href="https://github.com/vulnerability-lookup/vulnerability-lookup" title="Source code of Vulnerability-Lookup" rel="noreferrer" target="_blank">{{ render_icon('github') }} Source code</a></li>
+            </ul>
           </div>
         </div>
       </div>
@@ -468,14 +477,18 @@
 
         // Show the button when scrolled down
         const scrollToTopBtn = document.getElementById("scrollToTopBtn");
+        const vlTopbar = document.getElementById("vlTopbar");
 
-        function toggleScrollBtn() {
-          const show = document.documentElement.scrollTop > 500;
+        function onScroll() {
+          const y = document.documentElement.scrollTop;
+          const show = y > 500;
           scrollToTopBtn.classList.toggle("show", show);
           scrollToTopBtn.classList.toggle("d-none", !show);
+          if (vlTopbar) vlTopbar.classList.toggle("is-scrolled", y > 4);
         }
 
-        window.addEventListener("scroll", () => requestAnimationFrame(toggleScrollBtn));
+        window.addEventListener("scroll", () => requestAnimationFrame(onScroll));
+        onScroll();
 
         scrollToTopBtn.addEventListener("click", () => {
           window.scrollTo({ top: 0, behavior: "smooth" });

--- a/website/web/templates/organizations/organization.html
+++ b/website/web/templates/organizations/organization.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="row mb-5">
   <div class="col-lg-8 offset-lg-2">
-    <div class="card shadow position-relative">
+    <div class="card vl-card shadow position-relative">
       {% if organization.icon_id %}
         <img id="project-logo"
              src="{{ url_for('uploaded_pictures', filename=organization.uuid) }}.png"
@@ -13,6 +13,7 @@
              alt="{{ organization.name }} logo" />
       {% endif %}
       <div class="card-body">
+        <span class="vl-eyebrow">Organization</span>
         <h3 id="organization-name">{{ organization.name }}</h3>
         <div class="mb-3">
           <div class="row">
@@ -51,7 +52,7 @@
 </div>
 
 <nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb p-3 rounded shadow-sm" style="background-color: #446d80; color: #fff;">
+  <ol class="breadcrumb p-3 rounded shadow-sm" style="background-color: var(--vl-slate); color: #fff;">
     <li class="breadcrumb-item active" style="color: #fff;" aria-current="page">
       {{ render_icon('box', title='Products') }} Products ({{ organization.products | count }})
     </li>
@@ -61,7 +62,7 @@
 <div class="row g-4">
   {% for product in organization.products %}
     <div class="col-12 col-md-6 col-lg-4">
-      <div class="card h-100 shadow">
+      <div class="card vl-card h-100 shadow">
         <div class="card-body d-flex flex-column">
           <h4 class="card-title">{{ product.name }}</h4>
           <p class="card-text text-justify flex-grow-1">{{ product.description }}</p>

--- a/website/web/templates/organizations/organizations.html
+++ b/website/web/templates/organizations/organizations.html
@@ -3,6 +3,7 @@
 {% block content %}
 <div class="row align-items-center mb-3">
   <div class="col-md-6">
+    <span class="vl-eyebrow">Community</span>
     <h1 class="mb-0">Organizations</h1>
   </div>
   <div class="col-md-3 d-flex align-items-center">
@@ -26,7 +27,7 @@
     <div class="list-group">
       {% for organization in organizations %}
         <nav aria-label="breadcrumb" class="mb-3">
-          <ol class="breadcrumb p-3 rounded shadow-sm d-flex justify-content-between align-items-center" style="background-color: #446d80; color: #fff;">
+          <ol class="breadcrumb p-3 rounded shadow-sm d-flex justify-content-between align-items-center" style="background-color: var(--vl-slate); color: #fff;">
             <li class="breadcrumb-item mb-0 text-white" aria-current="page">
               <strong><a class="text-white" href="{{ url_for('organization_bp.get_by_uuid', organization_uuid=organization.uuid) }}">{{ organization.name }}</a></strong>
             </li>
@@ -40,7 +41,7 @@
         <div class="row g-4 mb-5">
           {% for product in organization.products %}
             <div class="col-12 col-md-6 col-lg-4">
-              <div class="card h-100 shadow">
+              <div class="card vl-card h-100 shadow">
                 <div class="card-body d-flex flex-column gap-2">
                   <h5 class="card-title">{{ product.name }}</h5>
                   <p class="card-text text-justify flex-grow-1">{{ product.description }}</p>

--- a/website/web/templates/products/product.html
+++ b/website/web/templates/products/product.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="row mb-5">
   <div class="col-lg-8 offset-lg-2">
-    <div class="card shadow-sm position-relative">
+    <div class="card vl-card shadow-sm position-relative">
       {% if product.icon_id %}
         <img id="product-logo"
              src="{{ url_for('uploaded_pictures', filename=product.uuid) }}.png"
@@ -13,6 +13,7 @@
              alt="{{ product.name }} logo" />
       {% endif %}
       <div class="card-body">
+        <span class="vl-eyebrow">Product</span>
         <h3 id="product-name">{{ product.name }}</h3>
         <div class="mb-3">
           <h5>Description</h5>
@@ -44,7 +45,7 @@
 </div>
 
 <nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb p-3 rounded shadow-sm" style="background-color: #446d80; color: #fff;">
+  <ol class="breadcrumb p-3 rounded shadow-sm" style="background-color: var(--vl-slate); color: #fff;">
     <li class="breadcrumb-item active" style="color: #fff;" aria-current="page">
       {{ render_icon('bug', title='Vulnerabilities') }} Recent vulnerabilities
     </li>

--- a/website/web/templates/recent.html
+++ b/website/web/templates/recent.html
@@ -26,7 +26,10 @@
 </a>
 {% endmacro %}
 
-<h1 class="visually-hidden">Recent vulnerabilities</h1>
+<div class="mb-3">
+  <span class="vl-eyebrow">Vulnerabilities</span>
+  <h1 class="h3 mb-0">Recent vulnerabilities</h1>
+</div>
 <div class="input-group">
   <span class="input-group-text fw-semibold">Recent vulnerabilities from</span>
   <select class="form-select" id="sourceSelect"
@@ -105,7 +108,7 @@
         <span class="vl-icon-badge">{{ render_icon('clock-history') }}</span>
         <div class="flex-grow-1">
           <h2 class="h5 mb-0">{{ sources_to_show[selected_source] }}</h2>
-          <small class="text-body-secondary">Recent vulnerabilities · {{ total_count }} entr{{ 'y' if total_count == 1 else 'ies' }}</small>
+          <small class="text-body-secondary">Recent vulnerabilities · <span class="vl-tnum">{{ total_count }}</span> entr{{ 'y' if total_count == 1 else 'ies' }}</small>
         </div>
         <div class="d-flex gap-2 fs-5">
           <a class="icon-link" href="{{ url_for('home_bp.feed_recent', format='atom', source=source) }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>

--- a/website/web/templates/recent.html
+++ b/website/web/templates/recent.html
@@ -431,7 +431,7 @@
 </div>
 
 {% if total_pages > 1 %}
-<nav aria-label="Navigate vulnerabilities">
+<nav aria-label="Navigate vulnerabilities" class="mt-4">
   <ul class="pagination justify-content-center">
     <li class="page-item {% if current_page <= 1 %}disabled{% endif %}">
       <a class="page-link"

--- a/website/web/templates/search.html
+++ b/website/web/templates/search.html
@@ -1,4 +1,5 @@
 {% extends "main.html" %}
+{% from 'bootstrap5/utils.html' import render_icon %}
 {% import 'vulnerability_templates.html' as vuln_templates with context %}
 
 {% block head %}
@@ -40,13 +41,19 @@
 
 <div class="container my-4">
 
-  {# --- Always show refine/search form --- #}
-  <div class="card my-4">
-    <div class="card-body" id="search-criteria-body">
+  {# --- Page header --- #}
+  <div class="mb-4">
+    <span class="vl-eyebrow">Search</span>
+    <h1 class="h3 mb-0">Find a vulnerability</h1>
+  </div>
 
-      {% if fulltext_available %}
-      <h5 class="card-title d-flex align-items-center gap-2">
+  {# --- Always show refine/search form --- #}
+  <div class="card vl-card shadow-sm my-4">
+    <div class="card-header vl-card-header d-flex align-items-center gap-2">
+      <span class="vl-icon-badge vl-icon-badge-sm">{{ render_icon('search') }}</span>
+      <h5 class="card-title mb-0 d-flex align-items-center gap-2">
         Search criteria
+        {% if fulltext_available %}
         <span class="info-tooltip">
           ⓘ
           <span class="tooltip-box">
@@ -56,10 +63,10 @@
             Enable “Apply ordering” to sort by date instead of relevance.
           </span>
         </span>
+        {% endif %}
       </h5>
-      {% else %}
-      <h5 class="card-title">Search criteria</h5>
-      {% endif %}
+    </div>
+    <div class="card-body" id="search-criteria-body">
 
       <form class="row g-3 mt-2" method="GET" action="/search">
 
@@ -168,9 +175,11 @@
     </div>
   </div>
 
-  {# --- Single vulnerability view --- #}
+  {# --- Single vulnerability view (focal result carries the brand accent) --- #}
   {% if source %}
+  <div class="vl-primary-view">
   {{ render_vuln(source, vulnerability_id or vuln_id, vulnerability_data) }}
+  </div>
   {% endif %}
 
   {# --- Linked vulnerabilities --- #}
@@ -186,7 +195,7 @@
   {# --- Vendor/Product-specific vulnerabilities --- #}
   {% if vp_vulnerabilities %}
   <h2 class="mt-4">
-    {{ total_count }} {% if total_count == 1 %}vulnerability{% else %}vulnerabilities{% endif %}
+    <span class="vl-tnum">{{ total_count }}</span> {% if total_count == 1 %}vulnerability{% else %}vulnerabilities{% endif %}
     {% if product %}found for <span class="badge rounded-pill bg-primary">{{ product }}</span>{% endif %}
     {% if vendor %}by <span class="badge rounded-pill bg-secondary"><a class="text-white"
         href="{{ url_for('home_bp.search', vendor=vendor) }}">{{ vendor }}</a></span>{% endif %}

--- a/website/web/templates/sightings/sightings.html
+++ b/website/web/templates/sightings/sightings.html
@@ -13,7 +13,7 @@
 {% endblock %}
 {% block title %}Sightings{% endblock %}
 {% block content %}
-<div class="row">
+<div class="row mb-3">
   <div class="col-md-9">
     <span class="vl-eyebrow">Community</span>
     <h1 class="h3 mb-0">Sightings</h1>
@@ -103,7 +103,7 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row mt-4">
     <div class="col">
         {{ pagination.links }}
     </div>

--- a/website/web/templates/sightings/sightings.html
+++ b/website/web/templates/sightings/sightings.html
@@ -15,7 +15,8 @@
 {% block content %}
 <div class="row">
   <div class="col-md-9">
-    <h1>Sightings</h1>
+    <span class="vl-eyebrow">Community</span>
+    <h1 class="h3 mb-0">Sightings</h1>
   </div>
   <div class="col-md-3">
     <form class="align-items-center" method="GET">

--- a/website/web/templates/stats/stats.html
+++ b/website/web/templates/stats/stats.html
@@ -15,7 +15,10 @@
 {% block title %}Statistics{% endblock %}
 {% block content %}
 
-<h1 class="mb-4">Statistics</h1>
+<div class="mb-4">
+  <span class="vl-eyebrow">Insights</span>
+  <h1 class="h3 mb-0">Statistics</h1>
+</div>
 
 <div class="row">
   <div class="col">
@@ -104,6 +107,7 @@
 <!-- Period selector -->
 <div class="row align-items-center mt-5">
   <div class="col-md-6">
+    <span class="vl-eyebrow d-block mb-1">Filter rankings by period</span>
     <div class="d-flex align-items-center gap-2">
       <select id="yearPicker" class="form-select form-select-sm" style="width: auto;">
         <option value="">Year</option>

--- a/website/web/templates/user/account_recovery.html
+++ b/website/web/templates/user/account_recovery.html
@@ -25,7 +25,11 @@
 </div>
 <div class="row justify-content-center mt-3">
   <div class="col-md-4">
-    {{ render_form(form, extra_classes="form-control") }}
+    <div class="card vl-card shadow-sm">
+      <div class="card-body p-4">
+        {{ render_form(form, extra_classes="form-control") }}
+      </div>
+    </div>
   </div>
 </div>
 

--- a/website/web/templates/user/account_recovery_set_password.html
+++ b/website/web/templates/user/account_recovery_set_password.html
@@ -2,9 +2,14 @@
 {% from 'bootstrap5/form.html' import render_form %}
 {% block title %}Account recovery{% endblock %}
 {% block content %}
-<div class="row justify-content-center">
+<div class="row justify-content-center mt-4">
   <div class="col-md-4">
-    {{ render_form(form, extra_classes="form-control") }}
+    <div class="card vl-card shadow-sm">
+      <div class="card-body p-4">
+        <h1 class="h4 mb-3 text-center">Set a new password</h1>
+        {{ render_form(form, extra_classes="form-control") }}
+      </div>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/website/web/templates/user/bundles.html
+++ b/website/web/templates/user/bundles.html
@@ -1,7 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Your bundles{% endblock %}
 {% block content %}
-<h1>Your bundles</h1>
+<div class="mb-4"><span class="vl-eyebrow">Your account</span><h1 class="h3 mb-0">Your bundles</h1></div>
 <div class="table-responsive-md">
   <table id="table-bundles" class="table table-hover">
   <thead>

--- a/website/web/templates/user/comments.html
+++ b/website/web/templates/user/comments.html
@@ -1,7 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Your comments{% endblock %}
 {% block content %}
-<h1>Your comments</h1>
+<div class="mb-4"><span class="vl-eyebrow">Your account</span><h1 class="h3 mb-0">Your comments</h1></div>
 <div class="table-responsive-md">
   <table id="table-comments" class="table table-hover">
   <thead>

--- a/website/web/templates/user/edit_notification.html
+++ b/website/web/templates/user/edit_notification.html
@@ -7,6 +7,7 @@
 {% endblock %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Your account</span>
 <h1>{{ action }}</h1>
 <div class="row justify-content-center">
   {% if form_vendor_product  %}

--- a/website/web/templates/user/edit_user.html
+++ b/website/web/templates/user/edit_user.html
@@ -7,6 +7,7 @@
 {% endblock %}
 {% block title %}{{ action }}{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Your account</span>
 <h1>Profile</h1>
 {{ render_form(form, extra_classes="form-control") }}
 <br /><hr />

--- a/website/web/templates/user/login.html
+++ b/website/web/templates/user/login.html
@@ -25,12 +25,16 @@
 </div>
 <div class="row justify-content-center mt-3">
   <div class="col-md-4">
-    {{ render_form(form, extra_classes="form-control") }}
-    <div class="mt-3 text-center">
-      <p>
-        <a href="{{ url_for('user_bp.signup') }}">Sign up</a><br />
-        <a href="{{ url_for('user_bp.account_recovery') }}" rel="nofollow">Forgot your password?</a>
-      </p>
+    <div class="card vl-card shadow-sm">
+      <div class="card-body p-4">
+        {{ render_form(form, extra_classes="form-control") }}
+        <div class="mt-3 text-center">
+          <p>
+            <a href="{{ url_for('user_bp.signup') }}">Sign up</a><br />
+            <a href="{{ url_for('user_bp.account_recovery') }}" rel="nofollow">Forgot your password?</a>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/website/web/templates/user/notifications.html
+++ b/website/web/templates/user/notifications.html
@@ -1,6 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Your notifications{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Your account</span>
 <h1>
   <span class="text-decoration-none text-body">Your Notifications</span>
   <span class="mx-2 text-muted">›</span>

--- a/website/web/templates/user/organizations.html
+++ b/website/web/templates/user/organizations.html
@@ -1,7 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Your organizations{% endblock %}
 {% block content %}
-<h1>Your organizations</h1>
+<div class="mb-4"><span class="vl-eyebrow">Your account</span><h1 class="h3 mb-0">Your organizations</h1></div>
 
 <div class="table-responsive-md">
   <table id="table-organization" class="table table-hover">

--- a/website/web/templates/user/setup-2fa.html
+++ b/website/web/templates/user/setup-2fa.html
@@ -2,10 +2,9 @@
 {% from 'bootstrap5/form.html' import render_form %}
 {% block title %}Setup Two-Factor Authentication{% endblock %}
 {% block content %}
-<div class="row">
-  <div class="col-md-6">
-    <h5>Complete the two-factor authentication setup.</h5>
-  </div>
+<div class="mb-4">
+  <span class="vl-eyebrow">Security</span>
+  <h1 class="h3 mb-0">Set up two-factor authentication</h1>
 </div>
 <div class="row">
   <div class="col-md-6">

--- a/website/web/templates/user/sightings.html
+++ b/website/web/templates/user/sightings.html
@@ -1,7 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Your sightings{% endblock %}
 {% block content %}
-<h1>Your sightings</h1>
+<div class="mb-4"><span class="vl-eyebrow">Your account</span><h1 class="h3 mb-0">Your sightings</h1></div>
 
 <div class="table-responsive-md">
   <table id="table-sightings" class="table table-hover">

--- a/website/web/templates/user/signup.html
+++ b/website/web/templates/user/signup.html
@@ -26,7 +26,11 @@
 
 <div class="row justify-content-center mt-3">
   <div class="col-md-4">
-    {{ render_form(form, extra_classes="form-control") }}
+    <div class="card vl-card shadow-sm">
+      <div class="card-body p-4">
+        {{ render_form(form, extra_classes="form-control") }}
+      </div>
+    </div>
   </div>
 </div>
 

--- a/website/web/templates/user/user.html
+++ b/website/web/templates/user/user.html
@@ -7,124 +7,135 @@
 {% endblock %}
 {% block title %}{{ user.login }}{% endblock %}
 {% block content %}
-<div class="row mb-3">
-  <div class="col text-end">
-    <a class="icon-link me-2" href="{{ url_for('user_bp.feed_activity', login=user.login, format='atom') }}" type="application/atom+xml" title="Atom feed">
-      {{ render_icon('rss') }}
-    </a>
-    <a class="icon-link" href="{{ url_for('user_bp.feed_activity', login=user.login, format='rss') }}" type="application/atom+xml" title="RSS feed">
-      {{ render_icon('rss-fill') }}
-    </a>
-  </div>
-</div>
+{% set n_comments = user.comments.count() %}
+{% set n_bundles = user.bundles.count() %}
+{% set n_disclosures = user.vulnerability_disclosures.count() %}
 
-<div class="row align-items-center mb-4">
-  <div id="gravatar-container" class="col-md-2 text-center">
-    <img id="avatar" src="https://gravatar.com/avatar/{{ user.email | hash }}?s=220&d=404"
-         class="img-fluid rounded-circle" alt="Profile picture" title="Profile picture" />
-  </div>
-  <div class="col-md-6">
-    <span class="vl-eyebrow">Contributor</span>
-    <h1 class="mb-0">
-      {{ user.login }}
-      {% if current_user.is_authenticated and current_user.id == user.id %}<a class="ms-2 text-decoration-none" href="{{ url_for('user_bp.form') }}" title="Edit your profile">
-        {{ render_icon('pen', title='Edit your profile') }}
-      </a>{% endif %}
-    </h1>
-
-    <div class="mt-2">
-      {% if user.is_admin %}
-      <span class="badge rounded-pill bg-light border text-dark me-2" title="Administrator of the platform">
-        👑 Admin
-      </span>
-      {% endif %}
-      {% if top_contributor %}
-      <span class="badge rounded-pill bg-light border text-dark me-2" title="Trophy - Top contributor">
-        🏆 Top contributor
-      </span>
-      {% endif %}
-      {% if top_3_contributors %}
-      <span class="badge rounded-pill bg-light border text-dark me-2" title="Silver Medal - Among the top 3 contributors">
-        🥈 Top 3 contributors
-      </span>
-      {% endif %}
-      {% if not top_3_contributors and top_5_contributors %}
-      <span class="badge rounded-pill bg-light border text-dark me-2" title="Bronze Medal - Among the top 5 contributors">
-        🥉 Top 5 contributors
-      </span>
-      {% endif %}
-      {% if user.vulnerability_disclosures.all() | count > 0 %}
-      <span class="badge rounded-pill bg-light border text-dark" title="Vulnerability Reporter Medal">
-        {{ render_icon('bug', title='Vulnerability disclosures', color='red') }} Vulnerability reporter
-      </span>
-      {% endif %}
+<!-- Profile header -->
+<div class="card vl-card vl-card-accent shadow-sm mb-4">
+  <div class="card-body">
+    <div class="row align-items-center g-3">
+      <div id="gravatar-container" class="col-auto">
+        <img id="avatar" src="https://gravatar.com/avatar/{{ user.email | hash }}?s=240&d=404"
+             class="rounded-circle border" width="104" height="104" alt="Profile picture" title="Profile picture" />
+      </div>
+      <div class="col" style="min-width:0;">
+        <span class="vl-eyebrow">Contributor</span>
+        <h1 class="h2 mb-1">
+          {{ user.login }}
+          {% if current_user.is_authenticated and current_user.id == user.id %}<a class="ms-1 text-decoration-none fs-5" href="{{ url_for('user_bp.form') }}" title="Edit your profile">{{ render_icon('pen', title='Edit your profile') }}</a>{% endif %}
+        </h1>
+        <div class="text-body-secondary d-flex flex-wrap gap-3 small">
+          <span>{{ render_icon('calendar-event') }} Member since {{ user.created_at | datetimeformat('%B %d, %Y') }}</span>
+          {% if user_country %}<span>{{ render_icon('geo-alt', title='Location') }} {{ user_country }}</span>{% endif %}
+          {% if user.organisation %}<span>{{ render_icon('building', title='Organization') }} {{ user.organisation }}</span>{% endif %}
+          {% if user.organizations | count > 0 %}<span>{{ render_icon('people', title='Organizations') }} {{ user.organizations | join(', ') }}</span>{% endif %}
+        </div>
+        <div class="mt-2 d-flex flex-wrap gap-2">
+          {% if user.is_admin %}
+          <span class="badge rounded-pill bg-body-tertiary border text-body" title="Administrator of the platform">👑 Admin</span>
+          {% endif %}
+          {% if top_contributor %}
+          <span class="badge rounded-pill bg-body-tertiary border text-body" title="Trophy - Top contributor">🏆 Top contributor</span>
+          {% endif %}
+          {% if top_3_contributors %}
+          <span class="badge rounded-pill bg-body-tertiary border text-body" title="Silver Medal - Among the top 3 contributors">🥈 Top 3 contributors</span>
+          {% endif %}
+          {% if not top_3_contributors and top_5_contributors %}
+          <span class="badge rounded-pill bg-body-tertiary border text-body" title="Bronze Medal - Among the top 5 contributors">🥉 Top 5 contributors</span>
+          {% endif %}
+          {% if n_disclosures > 0 %}
+          <span class="badge rounded-pill bg-body-tertiary border text-body" title="Vulnerability Reporter Medal">{{ render_icon('bug', title='Vulnerability disclosures', color='red') }} Vulnerability reporter</span>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-auto align-self-start">
+        <a class="icon-link me-1" href="{{ url_for('user_bp.feed_activity', login=user.login, format='atom') }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
+        <a class="icon-link" href="{{ url_for('user_bp.feed_activity', login=user.login, format='rss') }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
+      </div>
     </div>
   </div>
 </div>
 
-<div class="row mb-4">
+<!-- Stat tiles -->
+<div class="row row-cols-2 row-cols-md-4 g-3 mb-4">
   <div class="col">
-    <p class="mb-1">{{ render_icon('calendar-event') }} Member since {{ user.created_at | datetimeformat('%B %d, %Y') }}.</p>
-    {% if user_country %}
-    <p class="mb-1">{{ render_icon('geo-alt', title='Location') }} {{ user_country }}</p>
-    {% endif %}
-    {% if user.organisation %}
-    <p class="mb-1">{{ render_icon('building', title='Organization') }} {{ user.organisation }}</p>
-    {% endif %}
-    {% if user.organizations | count > 0 %}
-    <p class="mb-1">{{ render_icon('people', title='Organizations') }} {{ user.organizations | join(', ') }}</p>
-    {% endif %}
-    {% if nb_contributions %}
-    <p class="mb-1">{{ render_icon('pen', title='Contributions') }} {{ nb_contributions }} contribution{% if nb_contributions > 1 %}s{% endif %}</p>
-    {% endif %}
-    {% if user.vulnerability_disclosures.all() | count > 0 %}
-    <p class="mb-1">{{ render_icon('bug', title='Vulnerability disclosures') }} {{ user.vulnerability_disclosures.count() }} vulnerability disclosure{% if user.vulnerability_disclosures.count() > 1 %}s{% endif %}</p>
-    {% endif %}
+    <div class="card vl-card vl-card-feature text-center h-100"><div class="card-body py-3">
+      <div class="h3 mb-0 vl-tnum">{{ nb_contributions or 0 }}</div>
+      <div class="vl-eyebrow">Contributions</div>
+    </div></div>
+  </div>
+  <div class="col">
+    <div class="card vl-card vl-card-feature text-center h-100"><div class="card-body py-3">
+      <div class="h3 mb-0 vl-tnum">{{ n_comments }}</div>
+      <div class="vl-eyebrow">Comments</div>
+    </div></div>
+  </div>
+  <div class="col">
+    <div class="card vl-card vl-card-feature text-center h-100"><div class="card-body py-3">
+      <div class="h3 mb-0 vl-tnum">{{ n_bundles }}</div>
+      <div class="vl-eyebrow">Bundles</div>
+    </div></div>
+  </div>
+  <div class="col">
+    <div class="card vl-card vl-card-feature text-center h-100"><div class="card-body py-3">
+      <div class="h3 mb-0 vl-tnum">{{ n_disclosures }}</div>
+      <div class="vl-eyebrow">Disclosures</div>
+    </div></div>
   </div>
 </div>
 
-<div class="row">
+<!-- Bio + Links -->
+{% if user.bio or user.webpage or user.github or user.linkedin or user.mastodon %}
+<div class="row g-4 mb-2">
   {% if user.bio %}
-  <div class="col-md-6 mb-4">
-    <div class="card vl-card">
-      <div class="card-body">
-        <h5 class="card-title">Bio</h5>
-        <p class="card-text">{{ user.bio | safe }}</p>
+  <div class="col-md-6">
+    <div class="card vl-card h-100">
+      <div class="card-header vl-card-header d-flex align-items-center gap-2">
+        <span class="vl-icon-badge vl-icon-badge-sm">{{ render_icon('person-lines-fill') }}</span>
+        <span class="fw-semibold">Bio</span>
       </div>
+      <div class="card-body markdown-description"><div class="card-text">{{ user.bio | safe }}</div></div>
     </div>
   </div>
   {% endif %}
-
+  {% if user.webpage or user.github or user.linkedin or user.mastodon %}
   <div class="col-md-6">
-    <ul class="list-group">
-      {% if user.webpage %}
-      <li class="list-group-item">{{ render_icon('globe') }} <a href="{{ user.webpage }}" rel="noreferrer me" target="_blank">{{ user.webpage }}</a></li>
-      {% endif %}
-      {% if user.github %}
-      <li class="list-group-item">{{ render_icon('github') }} <a href="https://github.com/{{ user.github }}" rel="noreferrer me" target="_blank">https://github.com/{{ user.github }}</a></li>
-      {% endif %}
-      {% if user.linkedin %}
-      <li class="list-group-item">{{ render_icon('linkedin') }} <a href="https://www.linkedin.com/in/{{ user.linkedin }}" rel="noreferrer me" target="_blank">https://www.linkedin.com/in/{{ user.linkedin }}</a></li>
-      {% endif %}
-      {% if user.mastodon %}
-      <li class="list-group-item">{{ render_icon('mastodon') }} <a href="{{ user.mastodon }}" rel="noreferrer me" target="_blank">{{ user.mastodon }}</a></li>
-      {% endif %}
-    </ul>
-  </div>
-</div>
-
-<hr />
-
-<div class="row">
-  <div class="col-md-6">
-    <div class="row">
-      <div class="col">
-        <h3>Recent comments</h3>
+    <div class="card vl-card h-100">
+      <div class="card-header vl-card-header d-flex align-items-center gap-2">
+        <span class="vl-icon-badge vl-icon-badge-sm">{{ render_icon('link-45deg') }}</span>
+        <span class="fw-semibold">Links</span>
       </div>
-        <div class="col text-end">
-          <a class="icon-link" href="{{ url_for('comments_bp.feed_comments', user=user.login, format='atom') }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
-          <a class="icon-link" href="{{ url_for('comments_bp.feed_comments', user=user.login, format='rss') }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
-        </div>
+      <ul class="list-group list-group-flush">
+        {% if user.webpage %}
+        <li class="list-group-item">{{ render_icon('globe') }} <a href="{{ user.webpage }}" rel="noreferrer me" target="_blank">{{ user.webpage }}</a></li>
+        {% endif %}
+        {% if user.github %}
+        <li class="list-group-item">{{ render_icon('github') }} <a href="https://github.com/{{ user.github }}" rel="noreferrer me" target="_blank">github.com/{{ user.github }}</a></li>
+        {% endif %}
+        {% if user.linkedin %}
+        <li class="list-group-item">{{ render_icon('linkedin') }} <a href="https://www.linkedin.com/in/{{ user.linkedin }}" rel="noreferrer me" target="_blank">linkedin.com/in/{{ user.linkedin }}</a></li>
+        {% endif %}
+        {% if user.mastodon %}
+        <li class="list-group-item">{{ render_icon('mastodon') }} <a href="{{ user.mastodon }}" rel="noreferrer me" target="_blank">{{ user.mastodon }}</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endif %}
+
+<hr class="my-4" />
+
+<div class="row g-4">
+  <div class="col-md-6">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h2 class="h5 mb-0">{{ render_icon('chat-left-text') }} Recent comments</h2>
+      <div>
+        <a class="icon-link" href="{{ url_for('comments_bp.feed_comments', user=user.login, format='atom') }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
+        <a class="icon-link" href="{{ url_for('comments_bp.feed_comments', user=user.login, format='rss') }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
+      </div>
     </div>
     <div id="list-comments">
         <div class="d-flex justify-content-center">
@@ -134,14 +145,12 @@
     <p><a href="{{ url_for('comments_bp.list_comments') }}">All comments</a>.</p>
   </div>
   <div class="col-md-6">
-    <div class="row">
-      <div class="col">
-        <h3>Recent bundles</h3>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h2 class="h5 mb-0">{{ render_icon('collection') }} Recent bundles</h2>
+      <div>
+        <a class="icon-link" href="{{ url_for('bundles_bp.feed_bundles', user=user.login, format='atom') }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
+        <a class="icon-link" href="{{ url_for('bundles_bp.feed_bundles', user=user.login, format='rss') }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
       </div>
-        <div class="col text-end">
-          <a class="icon-link" href="{{ url_for('bundles_bp.feed_bundles', user=user.login, format='atom') }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
-          <a class="icon-link" href="{{ url_for('bundles_bp.feed_bundles', user=user.login, format='rss') }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
-        </div>
     </div>
     <div id="list-bundles">
       <div class="d-flex justify-content-center">

--- a/website/web/templates/user/user.html
+++ b/website/web/templates/user/user.html
@@ -24,6 +24,7 @@
          class="img-fluid rounded-circle" alt="Profile picture" title="Profile picture" />
   </div>
   <div class="col-md-6">
+    <span class="vl-eyebrow">Contributor</span>
     <h1 class="mb-0">
       {{ user.login }}
       {% if current_user.is_authenticated and current_user.id == user.id %}<a class="ms-2 text-decoration-none" href="{{ url_for('user_bp.form') }}" title="Edit your profile">
@@ -85,7 +86,7 @@
 <div class="row">
   {% if user.bio %}
   <div class="col-md-6 mb-4">
-    <div class="card">
+    <div class="card vl-card">
       <div class="card-body">
         <h5 class="card-title">Bio</h5>
         <p class="card-text">{{ user.bio | safe }}</p>

--- a/website/web/templates/user/users.html
+++ b/website/web/templates/user/users.html
@@ -1,11 +1,11 @@
 {% extends "main.html" %}
 {% block title %}Browse profiles{% endblock %}
 {% block content %}
-<h1>Browse profiles</h1>
+<div class="mb-4"><span class="vl-eyebrow">Community</span><h1 class="h3 mb-0">Browse profiles</h1></div>
 {% for user in users %}
 <div class="row">
     <div class="col-md-7">
-        <div class="card">
+        <div class="card vl-card">
             <div class="card-body">
                 <div class="row justify-content-between">
                     <div class="col-md-5">

--- a/website/web/templates/user/users.html
+++ b/website/web/templates/user/users.html
@@ -2,34 +2,34 @@
 {% block title %}Browse profiles{% endblock %}
 {% block content %}
 <div class="mb-4"><span class="vl-eyebrow">Community</span><h1 class="h3 mb-0">Browse profiles</h1></div>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
 {% for user in users %}
-<div class="row">
-    <div class="col-md-7">
-        <div class="card vl-card">
-            <div class="card-body">
-                <div class="row justify-content-between">
-                    <div class="col-md-5">
-                        <h5 class="card-title"><a href="{{ url_for('user_bp.profile', login=user.login) }}">{{ user.name }}</a></h5>
-                        <h6 class="card-subtitle mb-2 text-body-secondary">
-                            {% if user.organisation %}from {{ user.organisation }}{% endif %}
-                        </h6>
-                    </div>
-                    <div class="col-md-2">
-                        <img src="https://gravatar.com/avatar/{{ user.email | hash }}?s=80&d=blank" style="border-radius: 50%;" />
-                    </div>
-                </div>
-                <p class="card-text">A member since {{ user.created_at | datetimeformat('%B %d, %Y') }}.</p>
-                <p class="card-text">
-                  Authored {{ user.comments.count() }} comment{% if user.comments.count() > 1  %}s{% endif %}
-                  and {{ user.bundles.count() }} bundle{% if user.bundles.count() > 1  %}s{% endif %}.
-                </p>
+  {% set n_comments = user.comments.count() %}
+  {% set n_bundles = user.bundles.count() %}
+  <div class="col">
+    <a href="{{ url_for('user_bp.profile', login=user.login) }}" class="text-decoration-none text-reset">
+      <div class="card vl-card vl-card-feature h-100">
+        <div class="card-body d-flex gap-3">
+          <img src="https://gravatar.com/avatar/{{ user.email | hash }}?s=112&d=blank"
+               class="rounded-circle flex-shrink-0 border" width="56" height="56" alt="" loading="lazy" />
+          <div class="flex-grow-1" style="min-width:0;">
+            <h5 class="card-title mb-0 text-truncate">{{ user.name }}</h5>
+            {% if user.organisation %}
+            <div class="text-body-secondary small text-truncate">{{ render_icon('building') }} {{ user.organisation }}</div>
+            {% endif %}
+            <div class="text-body-secondary small mt-1">{{ render_icon('calendar-event') }} Since {{ user.created_at | datetimeformat('%b %Y') }}</div>
+            <div class="d-flex flex-wrap gap-3 mt-2 small">
+              <span class="text-body-secondary" title="Comments authored">{{ render_icon('chat-left-text') }} <span class="vl-tnum">{{ n_comments }}</span></span>
+              <span class="text-body-secondary" title="Bundles created">{{ render_icon('collection') }} <span class="vl-tnum">{{ n_bundles }}</span></span>
             </div>
+          </div>
         </div>
-    </div>
-</div>
-<br />
+      </div>
+    </a>
+  </div>
 {% endfor %}
-<div class="row">
+</div>
+<div class="row mt-4">
     <div class="col">
         {{ pagination.links }}
     </div>

--- a/website/web/templates/user/verify-2fa.html
+++ b/website/web/templates/user/verify-2fa.html
@@ -4,19 +4,24 @@
 <div class="row justify-content-center">
   <div class="col-md-4">
     <main class="form-signin w-100 m-auto">
-      <form class="form form-control" role="form" method="post" action="">
-        {{ form.csrf_token }}
-        {{ form.otp(placeholder="OTP", class="form-control", autofocus=true) }}
-        {{ form.otp.label }}
-        {% if form.otp.errors %}
-          {% for error in form.otp.errors %}
-          <div class="alert alert-danger" role="alert">
-            {{ error }}
-          </div>
-          {% endfor %}
-        {% endif %}
-        <button class="btn btn-primary form-control" type="submit">Verify</button>
-      </form>
+      <div class="card vl-card shadow-sm">
+        <div class="card-body p-4">
+          <h1 class="h4 mb-3 text-center">Two-factor authentication</h1>
+          <form class="form form-control" role="form" method="post" action="">
+            {{ form.csrf_token }}
+            {{ form.otp(placeholder="OTP", class="form-control", autofocus=true) }}
+            {{ form.otp.label }}
+            {% if form.otp.errors %}
+              {% for error in form.otp.errors %}
+              <div class="alert alert-danger" role="alert">
+                {{ error }}
+              </div>
+              {% endfor %}
+            {% endif %}
+            <button class="btn btn-primary form-control" type="submit">Verify</button>
+          </form>
+        </div>
+      </div>
     </main>
   </div>
 </div>

--- a/website/web/templates/user/vulnerability_disclosures.html
+++ b/website/web/templates/user/vulnerability_disclosures.html
@@ -3,6 +3,7 @@
 {% block content %}
 <div class="row">
     <div class="col-md-9">
+      <span class="vl-eyebrow">Your account</span>
       <h1>Vulnerability disclosures</h1>
     </div>
     <div class="col-md-3">

--- a/website/web/templates/user/watchlist.html
+++ b/website/web/templates/user/watchlist.html
@@ -29,6 +29,7 @@
 {% endblock %}
 {% block title %}Your Watchlist{% endblock %}
 {% block content %}
+<span class="vl-eyebrow">Your account</span>
 <h1>
   <a href="{{ url_for('user_bp.list_notifications') }}" class="">Your Notifications</a>
   <span class="mx-2 text-muted">›</span>

--- a/website/web/templates/vuln.html
+++ b/website/web/templates/vuln.html
@@ -31,6 +31,17 @@
       color: var(--vl-slate);
   }
 
+  /* Monospace vulnerability identifiers — exclusive to this detail page.
+     The source-view macros are shared with the recent/search/product/cwe
+     pages, so we scope the treatment to the primary card and the related
+     tab here rather than tagging the macros themselves. */
+  .vl-primary-view .card-title a,
+  #related .card-title a {
+      font-family: var(--vl-font-mono);
+      font-size: 0.95em;
+      letter-spacing: -0.01em;
+  }
+
   /* Style to make the chart scrollable horizontally */
   .chart-container {
     position: relative; /* Required for positioning */

--- a/website/web/templates/vuln.html
+++ b/website/web/templates/vuln.html
@@ -28,7 +28,7 @@
   }
   .chevron {
       font-size: 18px;
-      color: #446d80;
+      color: var(--vl-slate);
   }
 
   /* Style to make the chart scrollable horizontally */
@@ -117,6 +117,7 @@
 
 
 
+<div class="vl-primary-view">
 {% if source ==  'nvd' %}
 {{vuln_templates.nvd_view(source=source, vulnerability_id=vulnerability_id, vulnerability_data=vulnerability_data)}}
 {% elif source ==  'cvelistv5' %}
@@ -267,27 +268,28 @@ Other source: {{source}}.
 {% if vulnerability_data == {} %}
 {{ vuln_templates.unpublished(vulnerability_id=vulnerability_id) }}
 {% endif %}
+</div>
 
 <br />
 <ul class="nav nav-tabs" id="pageTab" role="tablist">
   <li class="nav-item">
-    <button class="nav-link active" id="related-tab" data-bs-toggle="tab" data-bs-target="#related" role="tab" aria-controls="related" aria-selected="true" href="#related">Related vulnerabilities <span class="badge bg-primary rounded-pill">{{ nb_linked_vulns }}</span></button>
+    <button class="nav-link active" id="related-tab" data-bs-toggle="tab" data-bs-target="#related" role="tab" aria-controls="related" aria-selected="true" href="#related">Related vulnerabilities <span class="badge bg-primary rounded-pill vl-tnum">{{ nb_linked_vulns }}</span></button>
   </li>
   {% if config.user_accounts  %}
   <li class="nav-item">
-    <button class="nav-link" id="comments-tab" data-bs-toggle="tab" data-bs-target="#comments" role="tab" aria-controls="comments" aria-selected="false" onclick="loadComments()" href="#comments">Comments <span class="badge bg-primary rounded-pill" id="nb-comments">{{ nb_comments }}</span></button>
+    <button class="nav-link" id="comments-tab" data-bs-toggle="tab" data-bs-target="#comments" role="tab" aria-controls="comments" aria-selected="false" onclick="loadComments()" href="#comments">Comments <span class="badge bg-primary rounded-pill vl-tnum" id="nb-comments">{{ nb_comments }}</span></button>
   </li>
   <li class="nav-item">
-    <button class="nav-link" id="bundles-tab" data-bs-toggle="tab" data-bs-target="#bundles" role="tab" aria-controls="bundles" aria-selected="false" onclick="loadBundles()" href="#bundles">Bundles <span class="badge bg-primary rounded-pill" id="nb-bundles">{{ nb_bundles }}</span></button>
+    <button class="nav-link" id="bundles-tab" data-bs-toggle="tab" data-bs-target="#bundles" role="tab" aria-controls="bundles" aria-selected="false" onclick="loadBundles()" href="#bundles">Bundles <span class="badge bg-primary rounded-pill vl-tnum" id="nb-bundles">{{ nb_bundles }}</span></button>
   </li>
   <li class="nav-item">
-    <button class="nav-link" id="sightings-tab" data-bs-toggle="tab" data-bs-target="#sightings" role="tab" aria-controls="sightings" aria-selected="false" onclick="loadSightings()" href="#sightings">Sightings <span class="badge bg-primary rounded-pill" id="nb-sightings">{{ nb_sightings }}</span></button>
+    <button class="nav-link" id="sightings-tab" data-bs-toggle="tab" data-bs-target="#sightings" role="tab" aria-controls="sightings" aria-selected="false" onclick="loadSightings()" href="#sightings">Sightings <span class="badge bg-primary rounded-pill vl-tnum" id="nb-sightings">{{ nb_sightings }}</span></button>
   </li>
   <li class="nav-item">
     <button class="nav-link" id="cwes-tab" data-bs-toggle="tab" data-bs-target="#cwes" role="tab" aria-controls="cwes" aria-selected="false" onclick="loadCWEs()" href="#cwes">CWE mitigations</button>
   </li>
   <li class="nav-item">
-    <button class="nav-link" id="detection-rules-tab" data-bs-toggle="tab" data-bs-target="#detection-rules" role="tab" aria-controls="detection-rules" aria-selected="false" onclick="loadDetectionRules()" href="#detection-rules">Detection rules <span id="count-detection-rules" class="badge bg-primary rounded-pill"></span></button>
+    <button class="nav-link" id="detection-rules-tab" data-bs-toggle="tab" data-bs-target="#detection-rules" role="tab" aria-controls="detection-rules" aria-selected="false" onclick="loadDetectionRules()" href="#detection-rules">Detection rules <span id="count-detection-rules" class="badge bg-primary rounded-pill vl-tnum"></span></button>
   </li>
   <li class="nav-item">
     <button class="nav-link" id="emb3d-tab" data-bs-toggle="tab" data-bs-target="#emb3d" role="tab" aria-controls="emb3d" aria-selected="false" onclick="loadEmb3d()" href="#emb3d">EMB3D</button>

--- a/website/web/templates/vulnerability_templates.html
+++ b/website/web/templates/vulnerability_templates.html
@@ -574,7 +574,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://github.com/fkie-cad/nvd-json-data-feeds" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['published'] | string_to_datetime('%Y-%m-%d %H:%M') }} -
@@ -708,7 +708,7 @@
       <!-- LEFT: Title + Metadata -->
       <div class="flex-grow-1">
         <h4 class="card-title mb-0">
-          <a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}" {% if vulnerability_id | length > 25  %}data-bs-toggle="tooltip" data-bs-placement="left" title="{{ vulnerability_id | upper }}"{% endif %}>
+          <a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}" {% if vulnerability_id | length > 25  %}data-bs-toggle="tooltip" data-bs-placement="left" title="{{ vulnerability_id | upper }}"{% endif %}>
             {{ vulnerability_id | upper | truncate(25, true, '…') }}
           </a>
           {% if not is_gcve %}
@@ -1248,7 +1248,7 @@
       <!-- LEFT: Title + Metadata -->
       <div class="flex-grow-1">
         <h4 class="card-title mb-0">
-          <a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">
+          <a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">
             {{ vulnerability_id | upper }}
           </a>
         </h4>
@@ -1807,7 +1807,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="{{url}}" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['document']['tracking']['initial_release_date'] | string_to_datetime('%Y-%m-%d %H:%M') }} -
@@ -2402,7 +2402,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://gsd.id" rel="noreferrer" target="_blank">{{source}}</a>
           {% if 'gsd' in vulnerability_data %} - Updated: {{ vulnerability_data['gsd']['osvSchema']['modified'] | string_to_datetime('%Y-%m-%d %H:%M') }}{% endif %}
@@ -2462,7 +2462,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="{{ url_for('home_bp.recent') }}?source={{ source }}">{{source}}</a> -
           Published: {{ vulnerability_data['published'] | string_to_datetime('%Y-%m-%d %H:%M') }} -
@@ -2637,7 +2637,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.variotdbs.pl/vulns/"  rel="noreferrer" target="_blank">{{source}}</a> -
           Updated: {{ vulnerability_data['last_update_date'] | string_to_datetime('%Y-%m-%d %H:%M') }}
@@ -2657,7 +2657,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="http://fstec.ru/" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['Дата выявления'] }}
@@ -2753,7 +2753,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.cnvd.org.cn" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['openTime'] }}
@@ -2836,7 +2836,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://tailscale.com/security-bulletins"  rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['published'] }}
@@ -2863,7 +2863,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.cert.ssi.gouv.fr/avis"  rel="noreferrer" target="_blank">{{ source }}</a> -
           Published:  {{ vulnerability_data['initial_release_date'] | string_to_datetime('%Y-%m-%d') }} -
@@ -2965,7 +2965,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.cert.ssi.gouv.fr/alerte"  rel="noreferrer" target="_blank">{{ source }}</a> -
           Published:  {{ vulnerability_data['initial_release_date'] | string_to_datetime('%Y-%m-%d') }} -
@@ -3067,7 +3067,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://jvndb.jvn.jp/en/"  rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['dcterms:issued'] | string_to_datetime('%Y-%m-%d %H:%M') }} -

--- a/website/web/templates/vulnerability_templates.html
+++ b/website/web/templates/vulnerability_templates.html
@@ -574,7 +574,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://github.com/fkie-cad/nvd-json-data-feeds" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['published'] | string_to_datetime('%Y-%m-%d %H:%M') }} -
@@ -708,7 +708,7 @@
       <!-- LEFT: Title + Metadata -->
       <div class="flex-grow-1">
         <h4 class="card-title mb-0">
-          <a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}" {% if vulnerability_id | length > 25  %}data-bs-toggle="tooltip" data-bs-placement="left" title="{{ vulnerability_id | upper }}"{% endif %}>
+          <a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}" {% if vulnerability_id | length > 25  %}data-bs-toggle="tooltip" data-bs-placement="left" title="{{ vulnerability_id | upper }}"{% endif %}>
             {{ vulnerability_id | upper | truncate(25, true, '…') }}
           </a>
           {% if not is_gcve %}
@@ -1248,7 +1248,7 @@
       <!-- LEFT: Title + Metadata -->
       <div class="flex-grow-1">
         <h4 class="card-title mb-0">
-          <a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">
+          <a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">
             {{ vulnerability_id | upper }}
           </a>
         </h4>
@@ -1807,7 +1807,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="{{url}}" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['document']['tracking']['initial_release_date'] | string_to_datetime('%Y-%m-%d %H:%M') }} -
@@ -2402,7 +2402,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://gsd.id" rel="noreferrer" target="_blank">{{source}}</a>
           {% if 'gsd' in vulnerability_data %} - Updated: {{ vulnerability_data['gsd']['osvSchema']['modified'] | string_to_datetime('%Y-%m-%d %H:%M') }}{% endif %}
@@ -2462,7 +2462,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="{{ url_for('home_bp.recent') }}?source={{ source }}">{{source}}</a> -
           Published: {{ vulnerability_data['published'] | string_to_datetime('%Y-%m-%d %H:%M') }} -
@@ -2637,7 +2637,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.variotdbs.pl/vulns/"  rel="noreferrer" target="_blank">{{source}}</a> -
           Updated: {{ vulnerability_data['last_update_date'] | string_to_datetime('%Y-%m-%d %H:%M') }}
@@ -2657,7 +2657,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="http://fstec.ru/" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['Дата выявления'] }}
@@ -2753,7 +2753,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.cnvd.org.cn" rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['openTime'] }}
@@ -2836,7 +2836,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://tailscale.com/security-bulletins"  rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['published'] }}
@@ -2863,7 +2863,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.cert.ssi.gouv.fr/avis"  rel="noreferrer" target="_blank">{{ source }}</a> -
           Published:  {{ vulnerability_data['initial_release_date'] | string_to_datetime('%Y-%m-%d') }} -
@@ -2965,7 +2965,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://www.cert.ssi.gouv.fr/alerte"  rel="noreferrer" target="_blank">{{ source }}</a> -
           Published:  {{ vulnerability_data['initial_release_date'] | string_to_datetime('%Y-%m-%d') }} -
@@ -3067,7 +3067,7 @@
     <div class="card-header vl-card-header d-flex align-items-center gap-3">
       <span class="vl-icon-badge">{{ render_icon('shield-exclamation') }}</span>
       <div class="flex-grow-1">
-        <h4 class="card-title mb-0"><a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
+        <h4 class="card-title mb-0"><a class="vl-id" href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_id) }}">{{ vulnerability_id | upper }}</a></h4>
         <small class="text-body-secondary">
           Vulnerability from <a href="https://jvndb.jvn.jp/en/"  rel="noreferrer" target="_blank">{{source}}</a> -
           Published: {{ vulnerability_data['dcterms:issued'] | string_to_datetime('%Y-%m-%d %H:%M') }} -


### PR DESCRIPTION
## Summary

A bold-but-brand-faithful modernization of the web interface. Brand colors are preserved (slate `#446d80`, azure `#006FBA`); the work is a **token-driven rebuild of the design system** rather than a per-page rewrite, then rolled out across every significant page surface.

`theme.css` is now a layer over Bootstrap 5.3 that steers components through their own `--bs-*` custom properties scoped per `data-bs-theme`, so light/dark stay consistent instead of being overridden one selector at a time. Verified throughout in **both light and dark**.

## Design system (`website/web/static/css/theme.css`)

- Light + dark token blocks driving Bootstrap via `--bs-*`. Dark mode uses a deep **slate-ink** background (tinted toward the brand, deliberately not pure black).
- **Signature "signal line":** an animated slate→azure seam on a sticky frosted topbar, echoed as the nav hover indicator, as `.vl-card-accent` (left border on focal cards), and along the footer's top edge.
- Reusable utilities: `.vl-eyebrow` (section kickers), `.vl-tnum` (tabular numerals), `.vl-card-accent`, alongside the existing `.vl-card` / `.vl-card-feature` / `.vl-card-header` / `.vl-icon-badge` family.
- Explicit button / dropdown / form / table interaction states, a single on-brand `:focus-visible` ring, themed scrollbars, and a `prefers-reduced-motion` floor.

## Chrome (`main.html`)

- Navbar wrapped in a sticky, blurred topbar (with scroll-shadow); wrapper sits outside `{% block navigation %}` so child overrides still get the new chrome.
- Converted to a flexbox sticky footer (retires the old `position:absolute` 60px + `margin-bottom` hack); footer redesigned into a multi-column brand layout.

## Page coverage

- **Vulnerability detail** — focal record card carries the accent; identifiers render **monospace** (`.vl-id` treatment scoped to this page only — `.vl-primary-view` + `#related`); tab counts use `.vl-tnum`.
- **Search** — eyebrow header, criteria card on the card language, tnum count; the single focal result carries the accent.
- **Recent / Product / CWE detail** — eyebrow headers, tnum counts, tokenized breadcrumbs, `vl-card` on panels.
- **Community** (sightings, comments, bundles, organizations) — eyebrow headers, `vl-card` on org/product cards, tokenized breadcrumbs.
- **Bundle / comment detail** — category eyebrow + focal-card accent; dropped the dark-mode-awkward `table-light` thead.
- **User / contributor** — `/users` rebuilt into a responsive contributor-card grid; `/user/<login>` rebuilt around a header card, stat tiles, and Bio/Links cards.
- **Admin** — dashboard gets a visible header, `vl-card` panels and tnum stats; standalone-title pages get an `Admin` eyebrow; the breadcrumb-pattern list pages were intentionally left (already consistent — no duplicate `<h1>`).
- **Auth pages** (login, signup, recovery, 2FA setup/verify) — centered `vl-card` forms with titles where missing.
- **Edit forms** — eyebrow above titles; `vl-card` on form panels.
- **KEV** (catalogs list, a catalog, an entry) — eyebrow headers and tnum counts.
- **Statistics** — eyebrow header and a labelled period selector.

## Fixes

- Spacing: the sightings title/pagination and the `/recent` pagination no longer butt against their tables.

## Design decisions worth noting

- **Monospace identifiers are exclusive to the vulnerability detail page.** The source-view macros in `vulnerability_templates.html` are shared with recent/search/product/cwe, so the treatment is applied via page-local rules there rather than a global utility (the short-lived `.vl-id` utility was removed). UUIDs keep their `<code>` styling everywhere.
- The accent is reserved for **focal record cards** (vuln detail primary, single search result, bundle/comment detail); list cards stay quiet.
- The `#446d80` in `sightings/correlations.html` is a d3 runtime SVG fill (not CSS) and was left as-is.

## Verification

Every touched template parses via the real Jinja environment. The full app was booted locally (Kvrocks + Redis cache + gunicorn) and key pages were screenshotted with real data in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)