### PR TITLE
fix(stats): stop current-year charts at current month

### DIFF
--- a/website/web/templates/stats/stats.html
+++ b/website/web/templates/stats/stats.html
@@ -420,7 +420,9 @@ async function loadMultiYearEvolution(source) {
   backBtn.classList.add("d-none");
   chartTitle.textContent = `Monthly Evolution (last ${numYears} years)`;
 
-  const thisYear = new Date().getFullYear();
+  const now = new Date();
+  const thisYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
   const years = Array.from({ length: numYears }, (_, i) => thisYear - i).reverse();
 
 
@@ -434,6 +436,13 @@ async function loadMultiYearEvolution(source) {
     const monthlyValues = [];
 
     for (const month of months) {
+      const monthNumber = parseInt(month, 10);
+
+      if (year === thisYear && monthNumber > currentMonth) {
+        monthlyValues.push(null);
+        continue;
+      }
+
       const period = `${year}-${month}`;
 
       const resp = await fetch(`/api/stats/vulnerability/count?state=published&period=${period}&source=${source}`);
@@ -643,8 +652,17 @@ async function loadMonthlyVulnerabilities(year, datasetLabel, source) {
 
   const months = Array.from({ length: 12 }, (_, i) => i + 1);
   const values = [];
+  const now = new Date();
+  const numericYear = parseInt(year, 10);
+  const thisYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
 
   for (const month of months) {
+    if (numericYear === thisYear && month > currentMonth) {
+      values.push(null);
+      continue;
+    }
+
     const resp = await fetch(
       `/api/stats/vulnerability/count?state=${datasetLabel}&period=${year}-${String(month).padStart(2, "0")}&source=${source}`
     );

--- a/website/web/templates/stats/stats.html
+++ b/website/web/templates/stats/stats.html
@@ -706,6 +706,9 @@ async function loadMonthlyVulnerabilities(year, datasetLabel, source) {
     const prev = values[index - 1];
     const curr = values[index];
 
+    // Future (unfinished) months are null: show no delta instead of a bogus -100%/NaN%.
+    if (prev === null || curr === null) return [month];
+
     let formatted;
     if (prev === 0 && curr !== 0) {
       formatted = `${curr}`; // first appearance


### PR DESCRIPTION
### Motivation
- Prevent the /stats/ monthly charts from showing misleading data for the current year by avoiding plotting future months that are not yet finished.

### Description
- Updated `website/web/templates/stats/stats.html` to compute the current date (`now`, `thisYear`, `currentMonth`) in `loadMultiYearEvolution` and skip future months for the current year by inserting `null` values into the series before fetching the API, so Chart.js treats those months as missing data rather than zeros.
- Applied the same future-month handling to the drilldown function `loadMonthlyVulnerabilities` so the per-year monthly view also uses `null` for unfinished months.
- The change uses `null` placeholders for future months so Chart.js breaks the line for the current year instead of plotting through December.

### Testing
- Executed a small verification script that checks `website/web/templates/stats/stats.html` contains the `monthlyValues.push(null)` and `values.push(null)` safeguards, and the check passed.
- Ran `git diff --check` to ensure no whitespace or diff issues were introduced, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a55b68a08832582d6030094ef0348)