### PR TITLE
Preserve selected multi-year window when switching sources on stats page

### DIFF
--- a/website/web/templates/stats/stats.html
+++ b/website/web/templates/stats/stats.html
@@ -256,7 +256,6 @@ const cbSafePastel = [
 ];
 
   const yearWindowSelect = document.getElementById("yearWindowSelect");
-  const YEAR_WINDOW = 10; // number of years to plot
   let opt = document.createElement("option");
   opt.value = 0;
   opt.textContent = "Global evolution";
@@ -405,14 +404,7 @@ function randomColorForYear(year) {
 async function loadMultiYearEvolution(source) {
   if (!vulnerabilitieCanvas) return;
 
-  vulnCountSpinner.classList.remove("d-none");
-  vulnerabilitieCanvas.classList.add("d-none");
-  backBtn.classList.add("d-none");
-  chartTitle.textContent = `Monthly Evolution (last ${YEAR_WINDOW} years)`;
-
-
-  if (!vulnerabilitieCanvas) return;
-
+  currentSource = source;
   const numYears = parseInt(yearWindowSelect.value, 10);
 
   vulnCountSpinner.classList.remove("d-none");
@@ -927,9 +919,13 @@ async function loadMonthlyVulnerabilities(year, datasetLabel, source) {
     loadCWERanking(period);
   });
   sourcePicker.addEventListener("change", ()=>{
-    const period = getPeriod();
+    const selectedWindow = parseInt(yearWindowSelect.value, 10);
     evolutionMode = false;
-    loadVulnerabilitiesCount(sourcePicker.value);
+    if (selectedWindow === 0) {
+      loadVulnerabilitiesCount(sourcePicker.value);
+    } else {
+      loadMultiYearEvolution(sourcePicker.value);
+    }
   });
 
 });


### PR DESCRIPTION
### Motivation
- The multi-year overlay mode on the vulnerabilities chart reverted to the default yearly view when switching `sourcePicker`, so selecting e.g. “Last 4 years” did not render the expected overlaid monthly curves for other sources.

### Description
- Update `website/web/templates/stats/stats.html` JavaScript so `loadMultiYearEvolution` records the active `source` via `currentSource` and reads the selected window size from `yearWindowSelect` to set the chart title and year range dynamically.
- Remove the unused fixed `YEAR_WINDOW` constant and the duplicated setup block that referenced it, and change the `sourcePicker` `change` handler to call `loadMultiYearEvolution` when a trailing N-years window is selected, otherwise call `loadVulnerabilitiesCount`.

### Testing
- Ran `node --check /tmp/stats.js` to validate the inlined script syntax and it succeeded.
- Ran `git diff --check` to ensure there are no whitespace/patch issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b852d0db88325991fe5f19ec55552)
