### PR TITLE
Make admin disclosure vulnerability IDs clickable

### DIFF
--- a/website/web/templates/admin/vulnerability_disclosures.html
+++ b/website/web/templates/admin/vulnerability_disclosures.html
@@ -75,7 +75,11 @@
       <tr>
           <td>{{ vulnerability_disclosure.title  }}</td>
           <td><a href="{{ url_for('admin_user_bp.form_user', user_id=vulnerability_disclosure.reporter.id) }}">{{ vulnerability_disclosure.reporter.login }}</a></td>
-          <td>{{ vulnerability_disclosure.vulnerability_id }}</td>
+          <td>
+            {% if vulnerability_disclosure.vulnerability_id %}
+              <a href="{{ url_for('home_bp.vulnerability_view', vulnerability_id=vulnerability_disclosure.vulnerability_id) }}">{{ vulnerability_disclosure.vulnerability_id }}</a>
+            {% endif %}
+          </td>
           <td class="date">{{ vulnerability_disclosure.creation_timestamp | datetimeformat }}</td>
           <td class="date">{{ vulnerability_disclosure.updated_timestamp | datetimeformat }}</td>
           <td>{{ vulnerability_disclosure.state.name }}</td>


### PR DESCRIPTION
### Motivation
- Improve admin UX by making the `Vulnerability` column on the admin disclosures page link to the vulnerability detail view for quick navigation.

### Description
- Update `website/web/templates/admin/vulnerability_disclosures.html` to render `vulnerability_disclosure.vulnerability_id` as a link to `url_for('home_bp.vulnerability_view', vulnerability_id=...)` when an ID is present, leaving the cell empty when none.

### Testing
- Verified the template parses cleanly with `from jinja2 import Environment; Environment().parse(Path(...).read_text())` and ran `python -m compileall` on the template with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c262c75348325a81fd9171b5b2b6c)