### PR TITLE
fix: [perf] split sighting author lookup into UNION leg so trgm indexes apply

### DIFF
--- a/website/web/views/sighting.py
+++ b/website/web/views/sighting.py
@@ -30,7 +30,7 @@ from werkzeug import Response as WerkzeugResponse
 
 from vulnerabilitylookup.default import get_config
 from website.lib.utils import escape_ilike, inject_xslt
-from website.models import Sighting
+from website.models import Sighting, User
 from website.web.bootstrap import application, vulnerabilitylookup
 
 sightings_bp = Blueprint(
@@ -52,25 +52,32 @@ def list_sightings() -> str:
             uuid_obj = UUID(sighting_query)
         except Exception:
             uuid_obj = None
+        # The substring filters on source/vulnerability are served by the
+        # pg_trgm GIN indexes (migration c0e0ef260ade). Previously the author
+        # lookup shared a single OR with them, which forced a sequential scan:
+        # `Sighting.author.has(...)` compiles to a correlated EXISTS, and
+        # PostgreSQL only folds an OR into a BitmapOr when every arm is
+        # independently indexable on the scanned table (issue #415). Splitting
+        # the author lookup into its own UNION leg lets the planner drive the
+        # substring/type arms from the indexes (~770ms -> ~20ms on a large
+        # table). UNION (not UNION ALL) keeps each sighting once, matching the
+        # original OR semantics.
         if uuid_obj:
-            sightings = sightings.filter(
-                or_(
-                    Sighting.uuid == uuid_obj,
-                    Sighting.type == sighting_query,
-                    Sighting.source.ilike(f"%{escaped_query}%", escape="\\"),
-                    Sighting.vulnerability.ilike(f"%{escaped_query}%", escape="\\"),
-                    Sighting.author.has(login=sighting_query),
-                )
+            column_match = or_(
+                Sighting.uuid == uuid_obj,
+                Sighting.type == sighting_query,
+                Sighting.source.ilike(f"%{escaped_query}%", escape="\\"),
+                Sighting.vulnerability.ilike(f"%{escaped_query}%", escape="\\"),
             )
         else:
-            sightings = sightings.filter(
-                or_(
-                    Sighting.type == sighting_query,
-                    Sighting.source.ilike(f"%{escaped_query}%", escape="\\"),
-                    Sighting.vulnerability.ilike(f"%{escaped_query}%", escape="\\"),
-                    Sighting.author.has(login=sighting_query),
-                )
+            column_match = or_(
+                Sighting.type == sighting_query,
+                Sighting.source.ilike(f"%{escaped_query}%", escape="\\"),
+                Sighting.vulnerability.ilike(f"%{escaped_query}%", escape="\\"),
             )
+        sightings = Sighting.query.filter(column_match).union(
+            Sighting.query.join(Sighting.author).filter(User.login == sighting_query)
+        )
     sightings = sightings.order_by(Sighting.creation_timestamp.desc())
     page, per_page, offset = get_page_args(
         page_parameter="page", per_page_parameter="per_page"


### PR DESCRIPTION
## Summary
Follow-up to #431. That PR added the `pg_trgm` GIN indexes on `sighting.source` / `sighting.vulnerability`, but as its own "honest scope note" called out, the headline `list_sightings()` search still couldn't use them. This PR removes that last blocker.

## Problem
`list_sightings()` (`website/web/views/sighting.py`) filtered with a single `or_(...)` that mixed the indexable substring/type arms with the author lookup:

```python
or_(
    Sighting.type == sighting_query,
    Sighting.source.ilike(f"%{escaped_query}%"),
    Sighting.vulnerability.ilike(f"%{escaped_query}%"),
    Sighting.author.has(login=sighting_query),   # <-- correlated EXISTS
)
```

`Sighting.author.has(...)` compiles to a correlated `EXISTS` on the `user` table. PostgreSQL only folds an `OR` into a `BitmapOr` when **every** arm is independently indexable on the scanned table, so the `EXISTS` arm forced a full sequential scan — and the new trgm indexes were never used (confirmed by @claudex's `EXPLAIN ANALYZE` on #415).

## Change
Split the author lookup into its own `UNION` leg, leaving the substring/type/uuid arms in one indexable leg:

```python
sightings = Sighting.query.filter(column_match).union(
    Sighting.query.join(Sighting.author).filter(User.login == sighting_query)
)
```

`UNION` (not `UNION ALL`) keeps each sighting once, matching the original `OR` semantics. No template, route, or API change — the result set and ordering are unchanged.

## Validation (local DB, ~380k sightings)
1. **Result-set parity** — built the old `OR` query and the new `UNION` query against the live DB and compared returned `uuid` sets across **52 representative terms** (substring, type, author-login, UUID, `%`/`_` wildcards, no-match): **identical in every case** (e.g. `cedric` → 76,764 rows, `https://info` → 20,969, `%` → 33, `nonexistent-zzz` → 0).
2. **Index now used** — a selective `source ILIKE '%...%'`:
   - Old shape (predicate `OR`'d with the `EXISTS`): `Seq Scan on sighting` — **283 ms**
   - New shape (split out): `Bitmap Index Scan on ix_sighting_source_trgm` — **17 ms**
3. **Combined search query** — `~400 ms → ~120 ms`, and the `EXISTS`-driven full seq scan is gone.

## Questions
- [ ] Does it require a DB change? No — query restructure only (the indexes it relies on already shipped in #431).
- [ ] Are you using it in production?
- [x] Does it require a change in the API (PyVulnerabilityLookup)? No.

Refs #431. Closes #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
