### PR TITLE
Add DCAT-AP catalogue endpoints, documentation and tests

### DIFF
--- a/config/website.py.sample
+++ b/config/website.py.sample
@@ -115,6 +115,31 @@ API_CORS_ORIGINS = "*"
 # the canonical sync path.
 BULK_DUMPS_URL = "https://vulnerability.circl.lu/dumps/"
 
+
+# #### DCAT-AP catalogue ####
+# Enables RDF catalogue endpoints for open-data harvesters:
+# /catalog.rdf, /catalog.ttl, /.well-known/dcat-ap and /api/catalog.
+DCAT_AP_ENABLED = True
+DCAT_AP_CATALOG_ID = "vulnerability-lookup"
+DCAT_AP_TITLE = "Vulnerability-Lookup catalogue"
+DCAT_AP_DESCRIPTION = "Metadata catalogue for Vulnerability-Lookup datasets and data services."
+DCAT_AP_PUBLISHER_NAME = ADMIN_NAME
+DCAT_AP_PUBLISHER_URL = ADMIN_WEBSITE
+DCAT_AP_CONTACT_EMAIL = ADMIN_EMAIL
+DCAT_AP_LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/"
+DCAT_AP_LANGUAGES = ["en"]
+DCAT_AP_THEME_TAXONOMIES = [
+    "https://www.misp-project.org/taxonomies.html",
+]
+# Optional local directory used to enumerate concrete dump files as
+# dcat:Distribution entries. Defaults to $VULNERABILITY_LOOKUP_HOME/dumps.
+DCAT_AP_DUMPS_DIRECTORY = None
+# Optional operator-defined datasets merged into the generated catalogue.
+# Each item may define identifier, title, description, keywords, landing_page,
+# license_url, themes and distributions (access_url, download_url, media_type,
+# format, issued, modified, checksum).
+DCAT_AP_CUSTOM_DATASETS = []
+
 # Free-form description of the rate-limit posture on this instance. Shown
 # verbatim in the policy document. Keep it short and honest — clients rely
 # on it to set their own backoff defaults. Update this when you turn on

--- a/docs/access-patterns.md
+++ b/docs/access-patterns.md
@@ -142,6 +142,8 @@ clients can pick whichever fits:
 | Path | Audience | Format |
 | --- | --- | --- |
 | `/.well-known/api-policy.json` | Machine clients | JSON, structured |
+| `/.well-known/dcat-ap` | Open-data catalogues | DCAT-AP RDF, content-negotiated |
+| `/catalog.rdf` / `/catalog.ttl` | Open-data catalogues and humans | DCAT-AP RDF/XML or Turtle |
 | `/llms.txt` | LLM agents | Markdown, concise |
 | `/robots.txt` | Crawlers | Robots Exclusion + `Policy:` link |
 | `/.well-known/security.txt` | Security researchers | RFC 9116 |

--- a/docs/dcat-ap.md
+++ b/docs/dcat-ap.md
@@ -1,0 +1,200 @@
+# DCAT-AP catalogue
+
+This page documents the DCAT-AP discovery feature for Vulnerability-Lookup
+instances. It is intentionally scoped as metadata publication: it makes dumps,
+feeds, and API surfaces discoverable by open-data catalogues without changing the
+canonical synchronization guidance in [access patterns](access-patterns.md).
+
+## Why DCAT-AP fits
+
+DCAT-AP is the European application profile of W3C DCAT for sharing metadata
+about catalogues containing datasets and data services. DCAT-AP 3 is the target
+conformance profile for this feature and explicitly models `dcat:DataService`, so a Vulnerability-Lookup instance can describe both:
+
+- downloadable datasets, such as the optional NDJSON dumps published by an
+  operator;
+- data services, such as the public REST API, OpenAPI document, pub/sub stream,
+  and feed endpoints.
+
+The API description should stay high-level. DCAT describes the existence,
+ownership, access location, format, licence, and relation between datasets and
+services. Detailed operations, parameters, schemas, and response examples should
+remain in the OpenAPI document, linked from DCAT with `dcat:endpointDescription`.
+
+## Public endpoints
+
+Vulnerability-Lookup exposes a small catalogue blueprint with RDF serializations
+of the same metadata:
+
+| Endpoint | Media type | Purpose |
+| --- | --- | --- |
+| `/catalog.rdf` | `application/rdf+xml` | Default DCAT-AP catalogue document for portal harvesters. |
+| `/catalog.ttl` | `text/turtle` | Human-friendly RDF serialization for debugging and review. |
+| `/.well-known/dcat-ap` | `text/turtle` or content-negotiated RDF | Stable discovery alias from well-known metadata surfaces. |
+| `/api/catalog` | JSON-LD or content-negotiated RDF | API namespace alias for clients that discover only under `/api`. |
+
+The catalogue is generated on request from instance configuration, dump file
+metadata, custom dataset definitions, and route metadata. A later iteration can
+cache it and expose `ETag`/`Last-Modified` headers if catalogue generation needs
+to perform heavier filesystem work.
+
+## Catalogue model
+
+Use one `dcat:Catalog` per Vulnerability-Lookup instance. The catalogue should
+include:
+
+- `dct:title`, `dct:description`, `dct:publisher`, `dct:issued`,
+  `dct:modified`, `dct:language`, and `foaf:homepage`;
+- `dcat:themeTaxonomy` pointing to an operator-configurable taxonomy, defaulting
+  to a security/cybersecurity theme where available;
+- `dcat:dataset` links for each published dump family;
+- `dcat:service` links for each public API or feed surface;
+- `dct:license` and `dct:rights` values derived from operator configuration.
+
+Configuration keys in `config/website.py`:
+
+```python
+DCAT_AP_ENABLED = True
+DCAT_AP_CATALOG_ID = "vulnerability-lookup"
+DCAT_AP_TITLE = "Vulnerability-Lookup catalogue"
+DCAT_AP_DESCRIPTION = "Metadata catalogue for Vulnerability-Lookup datasets and data services."
+DCAT_AP_PUBLISHER_NAME = "Example operator"
+DCAT_AP_PUBLISHER_URL = "https://example.org/"
+DCAT_AP_CONTACT_EMAIL = "security@example.org"
+DCAT_AP_LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/"
+DCAT_AP_LANGUAGES = ["en"]
+DCAT_AP_THEME_TAXONOMIES = [
+    "https://www.misp-project.org/taxonomies.html",
+]
+DCAT_AP_DUMPS_DIRECTORY = None
+DCAT_AP_CUSTOM_DATASETS = []
+```
+
+The public CIRCL instance could override these values with CIRCL-specific
+publisher, contact, and licence metadata.
+
+## Dataset candidates
+
+Represent each dump family as a `dcat:Dataset`. If an instance does not publish
+bulk dumps (`BULK_DUMPS_URL = None`), omit these datasets rather than advertising
+unavailable files. The catalogue should enumerate every available dump file as its
+own `dcat:Distribution`, because the files can differ by source, content type,
+generation time, and operational purpose. A dump index or manifest can still be
+linked, but it should not replace per-file distribution metadata when the files
+are discoverable.
+
+| Dataset | Distributions | Notes |
+| --- | --- | --- |
+| Vulnerability dumps | NDJSON files under the configured dumps URL | Include one `dcat:Distribution` per current dump file, with a fallback index distribution only when enumeration is impossible. |
+| KEV catalogue dumps | NDJSON exports for Known Exploited Vulnerabilities catalogues | Use keywords for KEV, exploited vulnerabilities, and catalogue source names. |
+| Comments, bundles, sightings dumps | Optional NDJSON exports | Include only when the operator publishes them. |
+
+For each distribution, publish at least:
+
+- `dcat:accessURL` for the index page or distribution landing page;
+- `dcat:downloadURL` when the concrete file URL is known;
+- `dcat:mediaType` such as `application/x-ndjson` or `application/json`;
+- `dct:format`, `dct:license`, `dct:issued`, and `dct:modified` when known;
+- `spdx:checksum` if dump generation records checksums in a manifest.
+
+## Controlled vocabularies
+
+DCAT-AP 3 should allow operators to expose controlled vocabularies that make
+sense for their community. Vulnerability-Lookup should support MISP taxonomies as
+first-class controlled vocabularies by allowing configured taxonomy namespace URLs
+in `dcat:themeTaxonomy` and using MISP taxonomy predicates or tags as dataset and
+service keywords where appropriate.
+
+A dedicated MISP taxonomy for Vulnerability-Lookup/DCAT-AP would also be useful.
+It could define stable tags for catalogue content such as vulnerability dumps,
+KEV catalogues, sightings, comments, bundles, REST APIs, streams, feeds, and
+access policies. Publishing that taxonomy through the MISP taxonomies project
+would let operators reuse the same vocabulary in MISP, Vulnerability-Lookup, and
+open-data catalogues.
+
+## Custom datasets
+
+Operators should be able to add custom datasets without changing code. A simple
+configuration model can accept a list of additional dataset definitions with:
+
+- a stable identifier and multilingual title/description;
+- one or more `dcat:Distribution` entries with `accessURL`, optional
+  `downloadURL`, media type, format, licence, checksum, issued, and modified
+  metadata;
+- optional `dcat:keyword`, MISP taxonomy tags, landing page, temporal coverage,
+  and related Vulnerability-Lookup service identifiers;
+- an enabled flag so operators can stage metadata before publication.
+
+These custom entries should be merged with the generated Vulnerability-Lookup
+datasets at render time and validated with the same DCAT-AP 3 SHACL profile as
+the built-in catalogue.
+
+## Data service candidates
+
+DCAT-AP can describe API endpoints through `dcat:DataService`. Create one data
+service per coherent API surface so each service has a single primary endpoint
+URL and a clear description.
+
+| Service | `dcat:endpointURL` | `dcat:endpointDescription` | `dcat:servesDataset` |
+| --- | --- | --- | --- |
+| REST API | `/api/` | OpenAPI JSON document or Swagger UI | Vulnerability and related datasets when represented. |
+| Pub/sub stream | `/pubsub/subscribe/{topic}` landing documentation | Streaming documentation | Vulnerability, comment, bundle, and sighting datasets when exposed. |
+| RSS/Atom feeds | Feed landing page or concrete feed URLs | Feeds documentation | Recent vulnerability/comment/KEV datasets. |
+| API policy | `/.well-known/api-policy.json` | Access-patterns documentation | Catalogue-level service metadata rather than a dataset. |
+
+Use `dcat:endpointDescription` for machine-readable OpenAPI when available. A
+human Swagger UI can also be linked with `foaf:page`, but the machine-readable
+OpenAPI URL should be preferred for harvesting and automation.
+
+## Example Turtle sketch
+
+```turtle
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+<https://vulnerability.circl.lu/catalog.rdf>
+    a dcat:Catalog ;
+    dct:title "Vulnerability-Lookup catalogue"@en ;
+    dct:publisher <https://www.circl.lu/> ;
+    foaf:homepage <https://vulnerability.circl.lu/> ;
+    dcat:dataset <https://vulnerability.circl.lu/dcat/dataset/vulnerability-dumps> ;
+    dcat:service <https://vulnerability.circl.lu/dcat/service/rest-api> .
+
+<https://vulnerability.circl.lu/dcat/dataset/vulnerability-dumps>
+    a dcat:Dataset ;
+    dct:title "Vulnerability-Lookup NDJSON vulnerability dumps"@en ;
+    dcat:distribution <https://vulnerability.circl.lu/dcat/distribution/vulnerability-dumps-index> .
+
+<https://vulnerability.circl.lu/dcat/distribution/vulnerability-dumps-index>
+    a dcat:Distribution ;
+    dcat:accessURL <https://vulnerability.circl.lu/dumps/> ;
+    dcat:mediaType "application/x-ndjson" .
+
+<https://vulnerability.circl.lu/dcat/service/rest-api>
+    a dcat:DataService ;
+    dct:title "Vulnerability-Lookup REST API"@en ;
+    dcat:endpointURL <https://vulnerability.circl.lu/api/> ;
+    dcat:endpointDescription <https://vulnerability.circl.lu/api/swagger.json> ;
+    dcat:servesDataset <https://vulnerability.circl.lu/dcat/dataset/vulnerability-dumps> .
+```
+
+## Implementation notes
+
+The implementation lives in `website/web/dcat.py` and deliberately avoids a
+runtime RDF dependency. It emits deterministic Turtle, RDF/XML, and JSON-LD from
+the same internal catalogue model. The dump dataset uses `BULK_DUMPS_URL` for
+public URLs and enumerates local files from `DCAT_AP_DUMPS_DIRECTORY`, defaulting
+to `$VULNERABILITY_LOOKUP_HOME/dumps`. Custom dataset definitions from
+`DCAT_AP_CUSTOM_DATASETS` are merged into the generated catalogue at render time.
+
+A future enhancement can add SHACL validation against a DCAT-AP 3 profile in CI.
+
+## Decisions
+
+- Target DCAT-AP 3 for conformance.
+- Enumerate all available dump files as individual `dcat:Distribution` entries.
+- Allow MISP taxonomies as controlled vocabularies, and consider publishing a
+  Vulnerability-Lookup-specific taxonomy through the MISP taxonomies project.
+- Support operator-defined custom datasets through configuration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ performance-tuning
 
 feeds
 api
+dcat-ap
 access-patterns
 ```
 

--- a/tests/test_dcat.py
+++ b/tests/test_dcat.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from website.web.bootstrap import application
+from website.web.dcat import api_catalog_bp, catalog_bp
+
+
+if "catalog_bp" not in application.blueprints:
+    application.register_blueprint(catalog_bp)
+if "api_catalog_bp" not in application.blueprints:
+    application.register_blueprint(api_catalog_bp)
+
+
+def _configure(tmp_path: Path) -> None:
+    dumps_dir = tmp_path / "dumps"
+    dumps_dir.mkdir()
+    (dumps_dir / "cvelistv5.ndjson").write_text('{"id":"CVE-2024-0001"}\n')
+    (dumps_dir / "kev_entries.ndjson").write_text('{"vuln_id":"CVE-2024-0001"}\n')
+    application.config.update(
+        PLATFORM_URL="https://example.test",
+        BULK_DUMPS_URL="https://example.test/dumps/",
+        DCAT_AP_DUMPS_DIRECTORY=str(dumps_dir),
+        DCAT_AP_TITLE="Example Vulnerability-Lookup catalogue",
+        DCAT_AP_DESCRIPTION="Example DCAT-AP catalogue.",
+        DCAT_AP_LICENSE_URL="https://creativecommons.org/licenses/by/4.0/",
+        DCAT_AP_THEME_TAXONOMIES=["https://www.misp-project.org/taxonomies.html"],
+        DCAT_AP_CUSTOM_DATASETS=[
+            {
+                "identifier": "custom-threat-notes",
+                "title": "Custom threat notes",
+                "description": "Operator supplied contextual data.",
+                "keywords": ["custom", "MISP taxonomy: vulnerability-lookup:custom"],
+                "distributions": [
+                    {
+                        "identifier": "custom-threat-notes-json",
+                        "title": "Custom threat notes JSON",
+                        "access_url": "https://example.test/custom/",
+                        "download_url": "https://example.test/custom/threat-notes.json",
+                        "media_type": "application/json",
+                        "format": "JSON",
+                    }
+                ],
+            }
+        ],
+    )
+
+
+def test_catalog_turtle_enumerates_dumps_and_services(tmp_path: Path) -> None:
+    _configure(tmp_path)
+    response = application.test_client().get("/catalog.ttl")
+
+    assert response.status_code == 200
+    assert response.mimetype == "text/turtle"
+    body = response.get_data(as_text=True)
+    assert "a dcat:Catalog" in body
+    assert "a dcat:DataService" in body
+    assert "dcat:endpointURL <https://example.test/api/>" in body
+    assert "dcat:endpointDescription <https://example.test/api/swagger.json>" in body
+    assert "dcat:downloadURL <https://example.test/dumps/cvelistv5.ndjson>" in body
+    assert "dcat:downloadURL <https://example.test/dumps/kev_entries.ndjson>" in body
+    assert "https://www.misp-project.org/taxonomies.html" in body
+    assert "custom-threat-notes" in body
+
+
+def test_catalog_rdf_xml_and_content_negotiated_alias(tmp_path: Path) -> None:
+    _configure(tmp_path)
+    client = application.test_client()
+
+    response = client.get("/catalog.rdf")
+    assert response.status_code == 200
+    assert response.mimetype == "application/rdf+xml"
+    body = response.get_data(as_text=True)
+    assert "<dcat:Catalog" in body
+    assert "<dcat:DataService" in body
+
+    negotiated = client.get("/.well-known/dcat-ap", headers={"Accept": "application/rdf+xml"})
+    assert negotiated.status_code == 200
+    assert negotiated.mimetype == "application/rdf+xml"
+
+
+def test_api_catalog_defaults_to_json_ld(tmp_path: Path) -> None:
+    _configure(tmp_path)
+    response = application.test_client().get("/api/catalog")
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/ld+json"
+    payload = json.loads(response.get_data(as_text=True))
+    assert payload["@type"] == "dcat:Catalog"
+    assert {service["@id"] for service in payload["dcat:service"]}
+
+
+def test_catalog_omits_dump_dataset_when_bulk_dumps_disabled(tmp_path: Path) -> None:
+    _configure(tmp_path)
+    application.config.update(
+        BULK_DUMPS_URL=None,
+        DCAT_AP_CUSTOM_DATASETS=[],
+    )
+
+    response = application.test_client().get("/catalog.ttl")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "vulnerability-lookup-dumps" not in body
+    assert "dcat:downloadURL <https://example.test/dumps/" not in body
+    assert "a dcat:DataService" in body

--- a/website/app.py
+++ b/website/app.py
@@ -13,6 +13,9 @@ with application.app_context():
     from website.web import views
 
     application.register_blueprint(views.home_bp)
+    if application.config.get("DCAT_AP_ENABLED", True):
+        application.register_blueprint(views.catalog_bp)
+        application.register_blueprint(views.api_catalog_bp)
     application.register_blueprint(views.assigners_bp)
     application.register_blueprint(views.documentation_bp)
     application.register_blueprint(views.stats_bp)

--- a/website/web/dcat.py
+++ b/website/web/dcat.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+from html import escape as html_escape
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urljoin
+
+from flask import Blueprint, Response, request
+
+from vulnerabilitylookup import __version__
+from vulnerabilitylookup.default import get_config, get_homedir
+from website.web.bootstrap import application
+
+TURTLE_MIMETYPE = "text/turtle; charset=utf-8"
+RDF_XML_MIMETYPE = "application/rdf+xml; charset=utf-8"
+JSON_LD_MIMETYPE = "application/ld+json; charset=utf-8"
+
+
+@dataclass
+class Distribution:
+    identifier: str
+    title: str
+    access_url: str
+    download_url: str | None = None
+    media_type: str | None = None
+    format: str | None = None
+    license_url: str | None = None
+    issued: str | None = None
+    modified: str | None = None
+    checksum: str | None = None
+
+
+@dataclass
+class Dataset:
+    identifier: str
+    title: str
+    description: str
+    keywords: list[str] = field(default_factory=list)
+    landing_page: str | None = None
+    license_url: str | None = None
+    themes: list[str] = field(default_factory=list)
+    distributions: list[Distribution] = field(default_factory=list)
+
+
+@dataclass
+class DataService:
+    identifier: str
+    title: str
+    description: str
+    endpoint_url: str
+    endpoint_description: str | None = None
+    serves_dataset: list[str] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+
+
+def _cfg(name: str, default: Any = None) -> Any:
+    return application.config.get(name, default)
+
+
+def _base_url() -> str:
+    configured = str(_cfg("PLATFORM_URL", "")).rstrip("/")
+    if configured:
+        return configured
+    return request.url_root.rstrip("/")
+
+
+def _catalog_url(base_url: str) -> str:
+    return f"{base_url}/catalog.rdf"
+
+
+def _literal(value: Any) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _iri(value: str) -> str:
+    return f"<{value}>"
+
+
+def _slug(value: str) -> str:
+    return quote(value.strip().lower().replace(" ", "-").replace("/", "-"), safe="-_~.")
+
+
+def _xml(value: Any) -> str:
+    return html_escape(str(value), quote=True)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _configured_languages() -> list[str]:
+    languages = _cfg("DCAT_AP_LANGUAGES", ["en"])
+    if isinstance(languages, str):
+        return [languages]
+    return [str(language) for language in languages] or ["en"]
+
+
+def _configured_taxonomies() -> list[str]:
+    taxonomies = _cfg(
+        "DCAT_AP_THEME_TAXONOMIES",
+        ["https://www.misp-project.org/taxonomies.html"],
+    )
+    if isinstance(taxonomies, str):
+        return [taxonomies]
+    return [str(taxonomy) for taxonomy in taxonomies if taxonomy]
+
+
+def _dump_directory() -> Path:
+    configured = _cfg("DCAT_AP_DUMPS_DIRECTORY")
+    if configured:
+        return Path(str(configured)).expanduser()
+    return get_homedir() / "dumps"
+
+
+def _file_distribution(dumps_url: str, path: Path) -> Distribution:
+    stat = path.stat()
+    modified = datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(
+        timespec="seconds"
+    )
+    name = path.name
+    title = path.stem.replace("_", " ").replace("-", " ").title()
+    return Distribution(
+        identifier=f"dump-{path.stem}",
+        title=f"{title} NDJSON dump",
+        access_url=dumps_url,
+        download_url=urljoin(dumps_url.rstrip("/") + "/", quote(name)),
+        media_type="application/x-ndjson",
+        format="NDJSON",
+        license_url=_cfg("DCAT_AP_LICENSE_URL"),
+        modified=modified,
+    )
+
+
+def _dump_distributions() -> list[Distribution]:
+    dumps_url = _cfg("BULK_DUMPS_URL")
+    if not dumps_url:
+        return []
+
+    directory = _dump_directory()
+    if directory.exists() and directory.is_dir():
+        files = sorted(path for path in directory.iterdir() if path.is_file())
+        distributions = [
+            _file_distribution(str(dumps_url), path)
+            for path in files
+            if path.suffix.lower() in {".ndjson", ".json", ".jsonl"}
+        ]
+        if distributions:
+            return distributions
+
+    return [
+        Distribution(
+            identifier="dumps-index",
+            title="Vulnerability-Lookup dump index",
+            access_url=str(dumps_url),
+            media_type="text/html",
+            format="HTML",
+            license_url=_cfg("DCAT_AP_LICENSE_URL"),
+        )
+    ]
+
+
+def _custom_datasets() -> list[Dataset]:
+    datasets: list[Dataset] = []
+    for item in _cfg("DCAT_AP_CUSTOM_DATASETS", []) or []:
+        if not isinstance(item, dict) or item.get("enabled", True) is False:
+            continue
+        distributions: list[Distribution] = []
+        for raw_distribution in item.get("distributions", []) or []:
+            if not isinstance(raw_distribution, dict):
+                continue
+            access_url = raw_distribution.get("access_url") or raw_distribution.get(
+                "accessURL"
+            )
+            if not access_url:
+                continue
+            dist_id = str(
+                raw_distribution.get("identifier")
+                or raw_distribution.get("id")
+                or _slug(str(raw_distribution.get("title") or access_url))
+            )
+            distributions.append(
+                Distribution(
+                    identifier=dist_id,
+                    title=str(raw_distribution.get("title") or dist_id),
+                    access_url=str(access_url),
+                    download_url=raw_distribution.get("download_url")
+                    or raw_distribution.get("downloadURL"),
+                    media_type=raw_distribution.get("media_type")
+                    or raw_distribution.get("mediaType"),
+                    format=raw_distribution.get("format"),
+                    license_url=raw_distribution.get("license_url")
+                    or raw_distribution.get("license"),
+                    issued=raw_distribution.get("issued"),
+                    modified=raw_distribution.get("modified"),
+                    checksum=raw_distribution.get("checksum"),
+                )
+            )
+        dataset_id = str(item.get("identifier") or item.get("id") or _slug(item["title"]))
+        datasets.append(
+            Dataset(
+                identifier=dataset_id,
+                title=str(item.get("title") or dataset_id),
+                description=str(item.get("description") or ""),
+                keywords=[str(keyword) for keyword in item.get("keywords", [])],
+                landing_page=item.get("landing_page") or item.get("landingPage"),
+                license_url=item.get("license_url") or item.get("license"),
+                themes=[str(theme) for theme in item.get("themes", [])],
+                distributions=distributions,
+            )
+        )
+    return datasets
+
+
+def _datasets(base_url: str) -> list[Dataset]:
+    datasets: list[Dataset] = []
+    distributions = _dump_distributions()
+    if distributions:
+        datasets.append(
+            Dataset(
+                identifier="vulnerability-lookup-dumps",
+                title="Vulnerability-Lookup dumps",
+                description=(
+                    "NDJSON bulk exports published by this Vulnerability-Lookup "
+                    "instance. Dumps are an open-data convenience; the API and "
+                    "stream remain the canonical synchronisation surfaces."
+                ),
+                keywords=[
+                    "vulnerability",
+                    "security advisory",
+                    "NDJSON",
+                    "MISP taxonomy: vulnerability-lookup:dumps",
+                ],
+                landing_page=str(_cfg("BULK_DUMPS_URL")),
+                license_url=_cfg("DCAT_AP_LICENSE_URL"),
+                distributions=distributions,
+            )
+        )
+    datasets.extend(_custom_datasets())
+    return datasets
+
+
+def _data_services(base_url: str, dataset_ids: list[str]) -> list[DataService]:
+    services = [
+        DataService(
+            identifier="rest-api",
+            title="Vulnerability-Lookup REST API",
+            description="REST API for querying and correlating vulnerability records.",
+            endpoint_url=f"{base_url}/api/",
+            endpoint_description=f"{base_url}/api/swagger.json",
+            serves_dataset=dataset_ids,
+            keywords=["API", "OpenAPI", "MISP taxonomy: vulnerability-lookup:api"],
+        ),
+        DataService(
+            identifier="api-policy",
+            title="Vulnerability-Lookup API policy",
+            description="Machine-readable access policy for automated API consumers.",
+            endpoint_url=f"{base_url}/.well-known/api-policy.json",
+            endpoint_description=(
+                "https://www.vulnerability-lookup.org/documentation/access-patterns.html"
+            ),
+            keywords=["policy", "automation"],
+        ),
+        DataService(
+            identifier="feeds",
+            title="Vulnerability-Lookup RSS and Atom feeds",
+            description="RSS and Atom feed surfaces for recent vulnerability and community updates.",
+            endpoint_url=f"{base_url}/recent/atom",
+            endpoint_description=(
+                "https://www.vulnerability-lookup.org/documentation/feeds.html"
+            ),
+            serves_dataset=dataset_ids,
+            keywords=["RSS", "Atom", "feeds"],
+        ),
+    ]
+    if get_config("stream", "pubsub_bp"):
+        services.append(
+            DataService(
+                identifier="pubsub-stream",
+                title="Vulnerability-Lookup pub/sub stream",
+                description="Server-Sent Events stream for real-time updates.",
+                endpoint_url=f"{base_url}/pubsub/subscribe/{{topic}}",
+                endpoint_description=(
+                    "https://www.vulnerability-lookup.org/documentation/streaming.html"
+                ),
+                serves_dataset=dataset_ids,
+                keywords=["SSE", "stream", "pubsub"],
+            )
+        )
+    return services
+
+
+def _resource_url(base_url: str, kind: str, identifier: str) -> str:
+    return f"{base_url}/dcat/{kind}/{_slug(identifier)}"
+
+
+def build_catalog_turtle() -> str:
+    base_url = _base_url()
+    catalog = _catalog_url(base_url)
+    datasets = _datasets(base_url)
+    services = _data_services(base_url, [dataset.identifier for dataset in datasets])
+    languages = _configured_languages()
+    taxonomies = _configured_taxonomies()
+    issued = str(_cfg("DCAT_AP_ISSUED") or _now())
+    modified = _now()
+    publisher_url = str(_cfg("DCAT_AP_PUBLISHER_URL") or _cfg("ADMIN_WEBSITE") or base_url)
+    publisher_name = str(_cfg("DCAT_AP_PUBLISHER_NAME") or _cfg("ADMIN_NAME") or _cfg("APP_NAME", "Vulnerability-Lookup"))
+    contact_email = _cfg("DCAT_AP_CONTACT_EMAIL") or _cfg("ADMIN_EMAIL")
+
+    lines = [
+        "@prefix dcat: <http://www.w3.org/ns/dcat#> .",
+        "@prefix dct: <http://purl.org/dc/terms/> .",
+        "@prefix foaf: <http://xmlns.com/foaf/0.1/> .",
+        "@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .",
+        "@prefix spdx: <http://spdx.org/rdf/terms#> .",
+        "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+        "",
+        f"{_iri(publisher_url)} a foaf:Agent ;",
+        f'    foaf:name "{_literal(publisher_name)}" .',
+        "",
+    ]
+    if contact_email:
+        lines.extend(
+            [
+                f"{_iri(base_url + '/dcat/contact')} a vcard:Kind ;",
+                f"    vcard:fn \"{_literal(publisher_name)}\" ;",
+                f"    vcard:hasEmail <mailto:{_literal(contact_email)}> .",
+                "",
+            ]
+        )
+
+    catalog_title = _cfg(
+        "DCAT_AP_TITLE",
+        _cfg("APP_NAME", "Vulnerability-Lookup") + " catalogue",
+    )
+    catalog_description = _cfg(
+        "DCAT_AP_DESCRIPTION",
+        "DCAT-AP catalogue for Vulnerability-Lookup datasets and data services.",
+    )
+    catalog_predicates = [
+        "a dcat:Catalog",
+        f'dct:identifier "{_literal(_cfg("DCAT_AP_CATALOG_ID", "vulnerability-lookup"))}"',
+        f'dct:title "{_literal(catalog_title)}"@{languages[0]}',
+        f'dct:description "{_literal(catalog_description)}"@{languages[0]}',
+        f"dct:publisher {_iri(publisher_url)}",
+        f"foaf:homepage {_iri(base_url + '/')}",
+        f'dct:issued "{_literal(issued)}"^^xsd:dateTime',
+        f'dct:modified "{_literal(modified)}"^^xsd:dateTime',
+    ]
+    for language in languages:
+        catalog_predicates.append(f'dct:language "{_literal(language)}"')
+    for taxonomy in taxonomies:
+        catalog_predicates.append(f"dcat:themeTaxonomy {_iri(taxonomy)}")
+    for dataset in datasets:
+        catalog_predicates.append(
+            f"dcat:dataset {_iri(_resource_url(base_url, 'dataset', dataset.identifier))}"
+        )
+    for service in services:
+        catalog_predicates.append(
+            f"dcat:service {_iri(_resource_url(base_url, 'service', service.identifier))}"
+        )
+    if contact_email:
+        catalog_predicates.append(f"dcat:contactPoint {_iri(base_url + '/dcat/contact')}")
+    lines.append(f"{_iri(catalog)}\n    " + " ;\n    ".join(catalog_predicates) + " .")
+    lines.append("")
+
+    for dataset in datasets:
+        dataset_url = _resource_url(base_url, "dataset", dataset.identifier)
+        predicates = [
+            "a dcat:Dataset",
+            f'dct:title "{_literal(dataset.title)}"@{languages[0]}',
+            f'dct:description "{_literal(dataset.description)}"@{languages[0]}',
+        ]
+        if dataset.landing_page:
+            predicates.append(f"dcat:landingPage {_iri(dataset.landing_page)}")
+        if dataset.license_url:
+            predicates.append(f"dct:license {_iri(dataset.license_url)}")
+        for keyword in dataset.keywords:
+            predicates.append(f'dcat:keyword "{_literal(keyword)}"@{languages[0]}')
+        for theme in dataset.themes:
+            predicates.append(f"dcat:theme {_iri(theme)}")
+        for distribution in dataset.distributions:
+            predicates.append(
+                f"dcat:distribution {_iri(_resource_url(base_url, 'distribution', distribution.identifier))}"
+            )
+        lines.append(f"{_iri(dataset_url)}\n    " + " ;\n    ".join(predicates) + " .")
+        lines.append("")
+
+        for distribution in dataset.distributions:
+            distribution_url = _resource_url(base_url, "distribution", distribution.identifier)
+            predicates = [
+                "a dcat:Distribution",
+                f'dct:title "{_literal(distribution.title)}"@{languages[0]}',
+                f"dcat:accessURL {_iri(distribution.access_url)}",
+            ]
+            if distribution.download_url:
+                predicates.append(f"dcat:downloadURL {_iri(distribution.download_url)}")
+            if distribution.media_type:
+                predicates.append(f'dcat:mediaType "{_literal(distribution.media_type)}"')
+            if distribution.format:
+                predicates.append(f'dct:format "{_literal(distribution.format)}"')
+            if distribution.license_url:
+                predicates.append(f"dct:license {_iri(distribution.license_url)}")
+            if distribution.issued:
+                predicates.append(f'dct:issued "{_literal(distribution.issued)}"^^xsd:dateTime')
+            if distribution.modified:
+                predicates.append(f'dct:modified "{_literal(distribution.modified)}"^^xsd:dateTime')
+            if distribution.checksum:
+                predicates.append(f'spdx:checksum "{_literal(distribution.checksum)}"')
+            lines.append(f"{_iri(distribution_url)}\n    " + " ;\n    ".join(predicates) + " .")
+            lines.append("")
+
+    for service in services:
+        service_url = _resource_url(base_url, "service", service.identifier)
+        predicates = [
+            "a dcat:DataService",
+            f'dct:title "{_literal(service.title)}"@{languages[0]}',
+            f'dct:description "{_literal(service.description)}"@{languages[0]}',
+            f"dcat:endpointURL {_iri(service.endpoint_url)}",
+        ]
+        if service.endpoint_description:
+            predicates.append(f"dcat:endpointDescription {_iri(service.endpoint_description)}")
+        for dataset_id in service.serves_dataset:
+            predicates.append(
+                f"dcat:servesDataset {_iri(_resource_url(base_url, 'dataset', dataset_id))}"
+            )
+        for keyword in service.keywords:
+            predicates.append(f'dcat:keyword "{_literal(keyword)}"@{languages[0]}')
+        lines.append(f"{_iri(service_url)}\n    " + " ;\n    ".join(predicates) + " .")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_catalog_rdf_xml() -> str:
+    # Keep RDF/XML simple and mechanically generated from the Turtle model's
+    # resources, without requiring an RDF library at runtime.
+    base_url = _base_url()
+    datasets = _datasets(base_url)
+    services = _data_services(base_url, [dataset.identifier for dataset in datasets])
+    title = _cfg("DCAT_AP_TITLE", _cfg("APP_NAME", "Vulnerability-Lookup") + " catalogue")
+    description = _cfg(
+        "DCAT_AP_DESCRIPTION",
+        "DCAT-AP catalogue for Vulnerability-Lookup datasets and data services.",
+    )
+    publisher_url = str(_cfg("DCAT_AP_PUBLISHER_URL") or _cfg("ADMIN_WEBSITE") or base_url)
+    language = _configured_languages()[0]
+    parts = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+        'xmlns:dcat="http://www.w3.org/ns/dcat#" '
+        'xmlns:dct="http://purl.org/dc/terms/" '
+        'xmlns:foaf="http://xmlns.com/foaf/0.1/">',
+        f'  <dcat:Catalog rdf:about="{_xml(_catalog_url(base_url))}">',
+        f'    <dct:title xml:lang="{_xml(language)}">{_xml(title)}</dct:title>',
+        f'    <dct:description xml:lang="{_xml(language)}">{_xml(description)}</dct:description>',
+        f'    <dct:publisher rdf:resource="{_xml(publisher_url)}" />',
+        f'    <foaf:homepage rdf:resource="{_xml(base_url + "/")}" />',
+    ]
+    for taxonomy in _configured_taxonomies():
+        parts.append(f'    <dcat:themeTaxonomy rdf:resource="{_xml(taxonomy)}" />')
+    for dataset in datasets:
+        parts.append(
+            f'    <dcat:dataset rdf:resource="{_xml(_resource_url(base_url, "dataset", dataset.identifier))}" />'
+        )
+    for service in services:
+        parts.append(
+            f'    <dcat:service rdf:resource="{_xml(_resource_url(base_url, "service", service.identifier))}" />'
+        )
+    parts.append("  </dcat:Catalog>")
+
+    for dataset in datasets:
+        parts.extend(
+            [
+                f'  <dcat:Dataset rdf:about="{_xml(_resource_url(base_url, "dataset", dataset.identifier))}">',
+                f'    <dct:title xml:lang="{_xml(language)}">{_xml(dataset.title)}</dct:title>',
+                f'    <dct:description xml:lang="{_xml(language)}">{_xml(dataset.description)}</dct:description>',
+            ]
+        )
+        for distribution in dataset.distributions:
+            parts.append(
+                f'    <dcat:distribution rdf:resource="{_xml(_resource_url(base_url, "distribution", distribution.identifier))}" />'
+            )
+        parts.append("  </dcat:Dataset>")
+        for distribution in dataset.distributions:
+            parts.extend(
+                [
+                    f'  <dcat:Distribution rdf:about="{_xml(_resource_url(base_url, "distribution", distribution.identifier))}">',
+                    f'    <dct:title xml:lang="{_xml(language)}">{_xml(distribution.title)}</dct:title>',
+                    f'    <dcat:accessURL rdf:resource="{_xml(distribution.access_url)}" />',
+                ]
+            )
+            if distribution.download_url:
+                parts.append(
+                    f'    <dcat:downloadURL rdf:resource="{_xml(distribution.download_url)}" />'
+                )
+            if distribution.media_type:
+                parts.append(f"    <dcat:mediaType>{_xml(distribution.media_type)}</dcat:mediaType>")
+            parts.append("  </dcat:Distribution>")
+
+    for service in services:
+        parts.extend(
+            [
+                f'  <dcat:DataService rdf:about="{_xml(_resource_url(base_url, "service", service.identifier))}">',
+                f'    <dct:title xml:lang="{_xml(language)}">{_xml(service.title)}</dct:title>',
+                f'    <dct:description xml:lang="{_xml(language)}">{_xml(service.description)}</dct:description>',
+                f'    <dcat:endpointURL rdf:resource="{_xml(service.endpoint_url)}" />',
+            ]
+        )
+        if service.endpoint_description:
+            parts.append(
+                f'    <dcat:endpointDescription rdf:resource="{_xml(service.endpoint_description)}" />'
+            )
+        for dataset_id in service.serves_dataset:
+            parts.append(
+                f'    <dcat:servesDataset rdf:resource="{_xml(_resource_url(base_url, "dataset", dataset_id))}" />'
+            )
+        parts.append("  </dcat:DataService>")
+    parts.append("</rdf:RDF>")
+    return "\n".join(parts) + "\n"
+
+
+def build_catalog_json_ld() -> str:
+    base_url = _base_url()
+    datasets = _datasets(base_url)
+    services = _data_services(base_url, [dataset.identifier for dataset in datasets])
+    return json.dumps(
+        {
+            "@context": {
+                "dcat": "http://www.w3.org/ns/dcat#",
+                "dct": "http://purl.org/dc/terms/",
+                "foaf": "http://xmlns.com/foaf/0.1/",
+            },
+            "@id": _catalog_url(base_url),
+            "@type": "dcat:Catalog",
+            "dct:title": _cfg(
+                "DCAT_AP_TITLE", _cfg("APP_NAME", "Vulnerability-Lookup") + " catalogue"
+            ),
+            "dct:description": _cfg(
+                "DCAT_AP_DESCRIPTION",
+                "DCAT-AP catalogue for Vulnerability-Lookup datasets and data services.",
+            ),
+            "dcat:dataset": [
+                {"@id": _resource_url(base_url, "dataset", dataset.identifier)}
+                for dataset in datasets
+            ],
+            "dcat:service": [
+                {"@id": _resource_url(base_url, "service", service.identifier)}
+                for service in services
+            ],
+            "foaf:homepage": {"@id": base_url + "/"},
+            "vulnerabilitylookup:version": __version__,
+        },
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def catalog_response(default: str = "turtle") -> Response:
+    accept = request.accept_mimetypes
+    choices = {
+        "turtle": (TURTLE_MIMETYPE, build_catalog_turtle),
+        "rdfxml": (RDF_XML_MIMETYPE, build_catalog_rdf_xml),
+        "jsonld": (JSON_LD_MIMETYPE, build_catalog_json_ld),
+    }
+    if accept.best_match(["application/rdf+xml", "text/turtle", "application/ld+json"]):
+        best = accept.best_match(["application/rdf+xml", "text/turtle", "application/ld+json"])
+        key = {
+            "application/rdf+xml": "rdfxml",
+            "text/turtle": "turtle",
+            "application/ld+json": "jsonld",
+        }[str(best)]
+    else:
+        key = default
+    mimetype, builder = choices[key]
+    return Response(builder(), mimetype=mimetype)
+
+
+catalog_bp = Blueprint("catalog_bp", __name__)
+api_catalog_bp = Blueprint("api_catalog_bp", __name__, url_prefix="/api")
+
+
+@catalog_bp.route("/catalog.rdf", methods=["GET"])
+def catalog_rdf():  # type: ignore[no-untyped-def]
+    return catalog_response(default="rdfxml")
+
+
+@catalog_bp.route("/catalog.ttl", methods=["GET"])
+def catalog_ttl():  # type: ignore[no-untyped-def]
+    return catalog_response(default="turtle")
+
+
+@catalog_bp.route("/.well-known/dcat-ap", methods=["GET"])
+def well_known_dcat_ap():  # type: ignore[no-untyped-def]
+    return catalog_response(default="turtle")
+
+
+@api_catalog_bp.route("/catalog", methods=["GET"])
+def api_catalog():  # type: ignore[no-untyped-def]
+    return catalog_response(default="jsonld")

--- a/website/web/views/__init__.py
+++ b/website/web/views/__init__.py
@@ -28,6 +28,7 @@ from website.web.views.assigner import assigners_bp
 from website.web.views.bundle import bundle_bp, bundles_bp
 from website.web.views.comment import comment_bp, comments_bp
 from website.web.views.CWEs import CWEs_bp
+from website.web.dcat import api_catalog_bp, catalog_bp
 from website.web.views.documentation import documentation_bp
 from website.web.views.home import home_bp
 from website.web.views.kev import kev_catalog_bp, kev_catalogs_bp
@@ -69,4 +70,6 @@ __all__ = [
     "cna_publication_bp",
     "CWEs_bp",
     "stats_bp",
+    "catalog_bp",
+    "api_catalog_bp",
 ]


### PR DESCRIPTION
### Motivation

- Expose a machine-readable DCAT-AP catalogue so open-data harvesters can discover dumps, feeds and API surfaces.  
- Provide a configurable, instance-local catalogue that advertises dump files, API services and operator-supplied custom datasets.  
- Surface the catalogue via well-known and content-negotiated endpoints so clients can choose Turtle, RDF/XML or JSON-LD.

### Description

- Introduce `website/web/dcat.py` implementing DCAT-AP catalogue model and builders for Turtle, RDF/XML and JSON-LD, plus `catalog_bp` and `api_catalog_bp` blueprints.  
- Conditionally register the new blueprints in `website/app.py` when `DCAT_AP_ENABLED` is enabled and export them from `website/web/views/__init__.py`.  
- Add configuration options to `config/website.py.sample` (e.g. `DCAT_AP_ENABLED`, `DCAT_AP_TITLE`, `DCAT_AP_DUMPS_DIRECTORY`, `DCAT_AP_CUSTOM_DATASETS`, etc.) and a short note in `access-patterns.md` and docs index.  
- Add comprehensive documentation `docs/dcat-ap.md` describing endpoints, configuration and catalogue modelling, and add unit tests in `tests/test_dcat.py` that exercise content negotiation, dump enumeration and custom dataset merging.

### Testing

- Added unit tests at `tests/test_dcat.py` covering Turtle, RDF/XML and JSON-LD responses, dump enumeration and behavior when `BULK_DUMPS_URL` is disabled.  
- Ran the new tests with `pytest tests/test_dcat.py`, and the test cases passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3e23911e548325aac191be10e6fbbf)