### PR TITLE
fix: align /recent feeds sort order and timestamps with the page

### DIFF
--- a/website/web/static/style.xsl
+++ b/website/web/static/style.xsl
@@ -144,15 +144,13 @@
               </xsl:choose>
 
 
-              <!-- Published date -->
-              <xsl:choose>
-                <xsl:when test="atom:published">
-                  <div class="meta">Published on <xsl:value-of select="atom:published"/></div>
-                </xsl:when>
-                <xsl:when test="atom:updated">
-                  <div class="meta">Published on <xsl:value-of select="atom:updated"/></div>
-                </xsl:when>
-              </xsl:choose>
+              <!-- Published / updated dates -->
+              <xsl:if test="atom:published">
+                <div class="meta">Published on <xsl:value-of select="atom:published"/></div>
+              </xsl:if>
+              <xsl:if test="atom:updated">
+                <div class="meta">Updated on <xsl:value-of select="atom:updated"/></div>
+              </xsl:if>
             </div>
           </xsl:for-each>
         </div>

--- a/website/web/templates/recent.html
+++ b/website/web/templates/recent.html
@@ -114,8 +114,8 @@
           <small class="text-body-secondary">Recent vulnerabilities · <span class="vl-tnum">{{ total_count }}</span> entr{{ 'y' if total_count == 1 else 'ies' }}</small>
         </div>
         <div class="d-flex gap-2 fs-5">
-          <a class="icon-link" href="{{ url_for('home_bp.feed_recent', format='atom', source=source) }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
-          <a class="icon-link" href="{{ url_for('home_bp.feed_recent', format='rss', source=source) }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
+          <a class="icon-link" href="{{ url_for('home_bp.feed_recent', format='atom', source=source, date_sort=date_sort, sort_order=sort_order) }}" type="application/atom+xml" title="Atom feed">{{ render_icon('rss') }}</a>
+          <a class="icon-link" href="{{ url_for('home_bp.feed_recent', format='rss', source=source, date_sort=date_sort, sort_order=sort_order) }}" type="application/atom+xml" title="RSS feed">{{ render_icon('rss-fill') }}</a>
         </div>
       </div>
       <div class="card-body p-0">

--- a/website/web/views/bundle.py
+++ b/website/web/views/bundle.py
@@ -106,7 +106,8 @@ def feed_bundles(per_page: int = 10, format: str = "atom") -> Response:
     bundles = query.offset(offset).limit(per_page)
 
     for bundle in bundles:
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to keep the query's newest-first order.
+        fe = fg.add_entry(order="append")
         fe.author(
             [
                 {

--- a/website/web/views/comment.py
+++ b/website/web/views/comment.py
@@ -200,7 +200,8 @@ def feed_comments(per_page: int = 10, format: str = "atom") -> Response:
     comments = query.offset(offset).limit(per_page)
 
     for comment in comments:
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to keep the query's newest-first order.
+        fe = fg.add_entry(order="append")
         fe.author(
             [
                 {

--- a/website/web/views/home.py
+++ b/website/web/views/home.py
@@ -933,6 +933,43 @@ def vulnerability_view(vulnerability_id: str) -> str | WerkzeugResponse:
     return redirect(url_for("home_bp.search", q=safe_vid))
 
 
+def _parse_feed_date(value: Any) -> datetime | None:
+    """Parse a feed timestamp into a timezone-aware datetime, or None."""
+    if not value:
+        return None
+    try:
+        dt = parser.isoparse(value) if isinstance(value, str) else value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def _feed_entry_dates(source: str, entry: dict[str, Any]) -> tuple[Any, Any]:
+    """Return the ``(published, updated)`` timestamps for a feed entry.
+
+    Mirrors the per-source date fields used by the ``recent.html`` table so the
+    feed's ``<published>``/``<updated>`` elements match the HTML view. Returns
+    ``(None, None)`` for sources without recognised date fields.
+    """
+    if source in ["cvelistv5", "nvd", "moksha", local_instance_name] or source.startswith("gna-"):
+        meta = entry.get("cveMetadata", {})
+        return meta.get("datePublished"), meta.get("dateUpdated")
+    if source == "fkie_nvd":
+        return entry.get("published"), entry.get("lastModified")
+    if source == "github":
+        return entry.get("published"), entry.get("modified")
+    if source in ["pysec", "ossf_malicious_packages", "bitnami_vulndb", "drupal", "cleanstart"] or source.startswith("osv_"):
+        return entry.get("published"), entry.get("modified")
+    if source.startswith("csaf_"):
+        tracking = entry.get("document", {}).get("tracking", {})
+        return tracking.get("initial_release_date"), tracking.get("current_release_date")
+    if source == "jvndb":
+        return entry.get("dcterms:issued"), entry.get("dcterms:modified")
+    return None, None
+
+
 @home_bp.route("/recent/<string:source>.<string:format>", methods=["GET"])
 @cache.cached(timeout=60, make_cache_key=feed_cache_key)
 def feed_recent(
@@ -942,6 +979,10 @@ def feed_recent(
     public_domain = get_config("generic", "public_domain")
     vulnerability = request.args.get("vulnerability", "")
     vendor = request.args.get("vendor", "")
+    # Mirror the /recent page defaults so the feed lists the same entries
+    # in the same order as the HTML view it is advertised from.
+    date_sort = request.args.get("date_sort", "updated")
+    sort_order = request.args.get("sort_order", "desc")
 
     page, per_page, _ = get_page_args(
         page_parameter="page", per_page_parameter="per_page"
@@ -978,7 +1019,7 @@ def feed_recent(
         ]
     elif vendor:
         vendor_vulns = vulnerabilitylookup.get_vendor_vulnerabilities(
-            vendor, "", sources, "published", "desc", per_page, page
+            vendor, "", sources, date_sort, sort_order, per_page, page
         )
         vulnerabilities = [
             (vuln_id, vuln)
@@ -987,12 +1028,13 @@ def feed_recent(
         ]
     else:
         vulnerabilities = vulnerabilitylookup.get_last(
-            source, "published", "desc", number=per_page, page=page
+            source, date_sort, sort_order, number=per_page, page=page
         )
 
-    # Add entries to feed
+    # Add entries to feed. feedgen prepends by default, which would reverse
+    # the order returned by get_last; append to preserve the /recent ordering.
     for vuln_id, entry in vulnerabilities:
-        fe = fg.add_entry()
+        fe = fg.add_entry(order="append")
         fe.id(f"https://{public_domain}/vuln/{vuln_id}")
         fe.title(vuln_id)
         fe.link(href=f"https://{public_domain}/vuln/{vuln_id}")
@@ -1009,27 +1051,17 @@ def feed_recent(
             fe.content(entry.get("containers", {}).get("cna", {}).get("title", ""))
             fe.description(entry.get("containers", {}).get("cna", {}).get("title", ""))
 
-        # Set published / updated date (uniform handling)
-        pub_date_str = None
-        if source in ["cvelistv5", "fkie_nvd", "nvd"] or "gna-" in source:
-            pub_date_str = entry.get("cveMetadata", {}).get("datePublished")
-        elif source == "github":
-            pub_date_str = entry.get("published")
-
-        if pub_date_str:
-            try:
-                dt = (
-                    parser.isoparse(pub_date_str)
-                    if isinstance(pub_date_str, str)
-                    else pub_date_str
-                )
-                if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=timezone.utc)
-                fe.published(dt)
-                fe.updated(dt)
-            except Exception:
-                # fallback: ignore invalid date formats
-                pass
+        # Set published / updated dates from the source's own fields so the
+        # feed timestamps match the /recent table (see _feed_entry_dates).
+        published_str, updated_str = _feed_entry_dates(source, entry)
+        published_dt = _parse_feed_date(published_str)
+        updated_dt = _parse_feed_date(updated_str)
+        if published_dt:
+            fe.published(published_dt)
+        # Atom requires <updated>; fall back to the published date when the
+        # source carries no separate modification timestamp.
+        if updated_dt or published_dt:
+            fe.updated(updated_dt or published_dt)
 
         fe.description()  # required by feedgen
 
@@ -1073,7 +1105,8 @@ def feed_kev(per_page: int = 10, format: str = "atom", source: str = "all") -> R
     for item in vulnerabilitylookup.get_all_entries_from_cisa_known_exploited(
         per_page, page
     ):
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to keep the newest-first order.
+        fe = fg.add_entry(order="append")
         fe.id(f"https://{public_domain}/vuln/{item['cveID']}")
         fe.title(f"{item['cveID']} - {item['vulnerabilityName']}")
         fe.link(href=f"https://{public_domain}/vuln/{item['cveID']}")

--- a/website/web/views/sighting.py
+++ b/website/web/views/sighting.py
@@ -204,7 +204,8 @@ def feed_sightings(per_page: int = 10, format: str = "atom") -> Response:
     sightings = query.offset(offset).limit(per_page)
 
     for sighting in sightings:
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to keep the query's newest-first order.
+        fe = fg.add_entry(order="append")
         fe.author(
             [
                 {
@@ -268,7 +269,8 @@ def feed_cpe_search(cpe: str, format: str = "atom") -> Response:
                 func.date(Sighting.creation_timestamp) >= some_times_ago,
             ).order_by(Sighting.creation_timestamp.desc()):
                 entry_url = f"https://{public_domain}/sighting/{sighting.uuid}"
-                fe = fg.add_entry()
+                # feedgen prepends by default; append to keep newest-first order.
+                fe = fg.add_entry(order="append")
                 fe.id(entry_url)  # Stable unique ID
                 fe.link(href=entry_url)
                 fe.title(str(sighting.uuid))

--- a/website/web/views/user.py
+++ b/website/web/views/user.py
@@ -593,7 +593,8 @@ def feed_activity(
     query = query.order_by(Comment.timestamp.desc())
     comments = query.offset(offset).limit(per_page)
     for comment in comments:
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to preserve the query's intended order.
+        fe = fg.add_entry(order="append")
         fe.id(f"https://{public_domain}/comment/{comment.uuid}")
         fe.title(comment.title)
         fe.link(href=f"https://{public_domain}/comment/{comment.uuid}")
@@ -606,7 +607,8 @@ def feed_activity(
     query = query.order_by(Bundle.timestamp.desc())
     bundles = query.offset(offset).limit(per_page)
     for bundle in bundles:
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to preserve the query's intended order.
+        fe = fg.add_entry(order="append")
         fe.id(f"https://{public_domain}/bundle/{bundle.uuid}")
         fe.title(bundle.name)
         fe.link(href=f"https://{public_domain}/bundle/{bundle.uuid}")
@@ -1069,7 +1071,8 @@ def watchlist_feed(format: str) -> WerkzeugResponse:
     fg.language("en")
 
     for vuln in vulns:
-        fe = fg.add_entry()
+        # feedgen prepends by default; append to preserve the query's intended order.
+        fe = fg.add_entry(order="append")
         fe.id(f"https://{public_domain}/vuln/{vuln[0]}")
         fe.title(f"{vuln[0]}")
         fe.link(href=f"https://{public_domain}/vuln/{vuln[0]}")


### PR DESCRIPTION
## Problem

The `/recent` Atom/RSS feeds (e.g. `/recent/cvelistv5.atom`) listed **different vulnerabilities, in a different order**, than the `/recent` page they are advertised from.

## Root causes

1. **Wrong sort field.** `feed_recent` hardcoded `date_sort="published"` / `order="desc"`, reading a different Kvrocks sorted set (`index:{source}:published`) than the page, which defaults to `date_sort="updated"` (`index:{source}`). The feed now honors the page's `date_sort`/`sort_order` query args (same `updated`/`desc` defaults), and the template feed links carry the current sort.

2. **Reversed order.** `feedgen`'s `add_entry()` defaults to `order="prepend"`, which silently reversed every backend-sorted feed (oldest-first instead of newest-first). All feeds that hand pre-sorted data to feedgen now use `order="append"`:
   - recent vulns + KEV (`home.py`), bundles, comments, sightings (incl. CPE search), user activity, watchlist.
   - `kev.py` already compensated via `reversed(kevs)` and is intentionally left untouched.

3. **Misleading timestamps.** The feed collapsed both `<published>` and `<updated>` to `datePublished` and only for a few sources. A new `_feed_entry_dates` helper maps each source to its own published/updated fields (mirroring the `recent.html` table), and `style.xsl` now shows **"Updated on"** in addition to "Published on" so the sort key is visible.

## Verification

Fetched `/recent/cvelistv5.atom?date_sort=updated&sort_order=desc` against a running instance: `<updated>` timestamps are now strictly descending and match the page ordering. (e.g. an entry published `2026-06-24` but updated `2026-06-29` now sorts by its update time, which previously made the list look unsorted.)

## Notes

- The user-activity feed still lists comments then bundles as two separate newest-first blocks (it never merged them by timestamp); append makes each block newest-first. Can follow up with a merged timeline if desired.
- The watchlist feed is sorted alphabetically by vendor/product; append now honors that ascending order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)